### PR TITLE
Updated to work with Chef 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
   - 1.8.7
+  - 1.9.3
 env:
-  - CHEF_VERSION=0.9.18
+  - CHEF_VERSION=0.10.8
+  - CHEF_VERSION=10.12.0
+  - CHEF_VERSION=10.14.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source "http://rubygems.org"
 
 # Add dependencies required to use your gem here.
-gem "chef", ">= 0.9.18"
-gem "dogapi", ">= 1.2"
+gem "chef", ">= 0.10"
+gem "dogapi", "~> 1.4"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "shoulda", ">= 0"
-  gem "bundler", ">= 1.0.0"
-  gem "jeweler", "~> 1.6.4"
-  gem "rdoc", ">= 0"
+  gem "shoulda", "~> 3.1"
+  gem "bundler"
+  gem "jeweler", "~> 1.8.4"
+  gem "rdoc", "~> 3.12"
 end


### PR DESCRIPTION
- Adds Travis Chef versions (currently unused, will be in effect for #10
- Adds Travis Ruby versions to test against MRI 1.9.3
- Updated Gemfile to reflect dependencies
