### PR TITLE
also set host tags from node attributes

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -94,8 +94,10 @@ class Chef
           host_tags = @dog.host_tags(hostname)[1]["tags"] || []
 
           # Add the explicit tags from node attributes
-          node.datadog.tags.each do |tag|
-            host_tags << tag
+          if node.datadog.tags.kind_of?(Array)
+            node.datadog.tags.each do |tag|
+              host_tags << tag
+            end
           end
 
           host_tags.delete_if {|tag| tag.start_with?('role:') }


### PR DESCRIPTION
A related pull request against chef-datadog will remove the `tags:` line from the datadog agent configuration, and update the chef handler dependency to use the (proposed) 0.2.0 version of the chef-handler-datadog gem.
