### PR TITLE
Loosen chef dependency

### DIFF
--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -1,9 +1,6 @@
-# -*- encoding: utf-8 -*-
-chef_version = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['~> 10.12']
 require File.expand_path('../lib/chef-handler-datadog', __FILE__)
 
 Gem::Specification.new do |gem|
-
   gem.name          = "chef-handler-datadog"
   gem.summary       = %q{Chef Handler for DataDog events and metrics}
   gem.description   = %q{This Handler will report the events and metrics for a chef-client run to DataDog.}
@@ -16,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
-  gem.add_dependency 'chef', chef_version
+  gem.add_dependency 'chef', ">= 10", "<= 12"
   gem.add_dependency 'dogapi', ">= 1.2"
 
   gem.add_development_dependency 'rake'
@@ -28,5 +25,4 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Mike Fiedler", "Adam Jacob", "Alexis Le-Quoc"]
   gem.email         = ["packages@datadoghq.com"]
   gem.homepage      = "http://www.datadoghq.com/"
-
 end


### PR DESCRIPTION
@alq666 Deployed datadog with it on a chef 11 host and did not blow up, so should be safe.
