### PR TITLE
enable passing a :hostname to the handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes
 
 # 0.4.0 / Unreleased
 
+* [FEATURE] Allow specification of a `:hostname` to config to override `node.name`, [#41][] [@miketheman][]
 * [FEATURE] Allow passing an array of handles in config to alert when Chef fails, [#29][] [@miketheman][]
 * [OPTIMIZE] Use new version of `dogapi` lib to submit tags for Chef only, [#28][] [@miketheman][]
 * [MISC] Updated versions of Chef tested
@@ -44,6 +45,7 @@ And all other versions were prior to this. See git history for more.
 [#34]: https://github.com/DataDog/chef-handler-datadog/issues/34
 [#37]: https://github.com/DataDog/chef-handler-datadog/issues/37
 [#39]: https://github.com/DataDog/chef-handler-datadog/issues/39
+[#41]: https://github.com/DataDog/chef-handler-datadog/issues/41
 [@alq]: https://github.com/alq
 [@miketheman]: https://github.com/miketheman
 [@remh]: https://github.com/remh

--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -20,7 +20,7 @@ class Chef
 
       def report
         # resolve correct hostname
-        hostname = select_hostname(run_status.node)
+        hostname = select_hostname(run_status.node, config)
 
         # Send the metrics
         emit_metrics_to_datadog(hostname, run_status)
@@ -208,13 +208,16 @@ class Chef
       # node's `ec2` attribute existence to make the decision.
       #
       # @param node [Chef::Node] from `run_status`, can feasibly any `node`
+      # @param config [Hash] config object passed in to handler
       # @return [String] the hostname decided upon
-      def select_hostname(node)
+      def select_hostname(node, config)
         use_ec2_instance_id = !config.key?(:use_ec2_instance_id) ||
                                 (config.key?(:use_ec2_instance_id) &&
                                   config[:use_ec2_instance_id])
 
-        if use_ec2_instance_id && node.attribute?('ec2') && node.ec2.attribute?('instance_id')
+        if config[:hostname]
+          config[:hostname]
+        elsif use_ec2_instance_id && node.attribute?('ec2') && node.ec2.attribute?('instance_id')
           node.ec2.instance_id
         else
           node.name

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1398702979,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:36:15 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:36:19 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1398702979,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:36:15 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:36:19 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1398702979,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:36:16 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:36:19 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1398702979,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-hostname ","priority":"low","parent":null,"tags":[],"aggregation_key":"chef.handler.datadog.test-hostname","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-hostname ","text":"Chef
+        updated 0 resources out of 0 resources total.","host":"chef.handler.datadog.test-hostname","device":null}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:36:16 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '376'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1398702979,
+        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-hostname
+        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2255530775220917022",
+        "text": "Chef updated 0 resources out of 0 resources total.", "tags": [],
+        "related_event_id": null, "id": 2255530775220917022}}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:36:19 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-hostname?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: ! '{"tags":["env:testing"]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Apr 2014 16:36:17 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/0.17.4
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"host": "chef.handler.datadog.test-hostname", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:36:19 GMT
+recorded_with: VCR 2.9.0

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1398703658,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:47:33 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:47:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1398703658,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:47:34 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:47:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1398703658,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:47:34 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"ok"}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:47:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1398703658,"msg_title":"Chef
+        completed in 5 seconds on my-imaginary-hostname.local ","priority":"low","parent":null,"tags":[],"aggregation_key":"my-imaginary-hostname.local","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on my-imaginary-hostname.local ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"my-imaginary-hostname.local","device":null}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Mon, 28 Apr 2014 16:47:34 GMT
+      Server:
+      - dogdispatcher/4.12.1
+      Content-Length:
+      - '369'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1398703658,
+        "handle": null, "title": "Chef completed in 5 seconds on my-imaginary-hostname.local
+        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2255542152438727835",
+        "text": "Chef updated 0 resources out of 0 resources total.", "tags": [],
+        "related_event_id": null, "id": 2255542152438727835}}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:47:38 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/my-imaginary-hostname.local?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: ! '{"tags":["env:testing"]}'
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Apr 2014 16:47:36 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/0.17.4
+      Content-Length:
+      - '64'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"host": "my-imaginary-hostname.local", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Mon, 28 Apr 2014 16:47:38 GMT
+recorded_with: VCR 2.9.0


### PR DESCRIPTION
In the event that some custom logic for setting a hostname is desired,
use the hostname passed in the configuration.

If the user has specified :use_ec2_instance_id in their configuration,
this will not be applied, as the existence of :hostname in the config
will override any other decisions.

Fixes #41
