### PR TITLE
allow string keys in config hash

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'rubygems'
 require 'chef/handler'
+require 'chef/mash'
 require 'dogapi'
 
 class Chef
@@ -13,9 +14,9 @@ class Chef
       # "Account Settings" page here: https://app.datadoghq.com/account/settings
       # It should be passed along from the node/role/environemnt attributes, as the default is nil.
       def initialize(config = {})
-        @config = config
+        @config = Mash.new(config)
         # If *any* api_key is not provided, this will fail immediately.
-        @dog = Dogapi::Client.new(config[:api_key], config[:application_key])
+        @dog = Dogapi::Client.new(@config[:api_key], @config[:application_key])
       end
 
       def report

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -23,6 +23,15 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
     )
   end
 
+  describe 'initialize' do
+    it 'should allow config hash to have string keys' do
+      Chef::Handler::Datadog.new(
+        'api_key'         => API_KEY,
+        'application_key' => APPLICATION_KEY,
+      )
+    end
+  end
+
   describe 'reports metrics event and sets tags' do
     # Construct a good run_status
     before(:each) do


### PR DESCRIPTION
This makes the class more flexible and allows the use of attributes to initialize the handler.

Example:

``` ruby
node.default['chef_client']['config']['report_handlers'] = [
  {
    'class' => 'Chef::Handler::Datadog',
    'arguments' => [
      'api_key' => node['datadog']['api_key'],
      'application_key' => node['datadog']['application_key'],
      'use_ec2_instance_id' => node['datadog']['use_ec2_instance_id']
    ]
  }
]
```
