### PR TITLE
Support for use of agent proxy settings by chef report handler

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -3,6 +3,9 @@ require 'rubygems'
 require 'chef/handler'
 require 'chef/mash'
 require 'dogapi'
+require_relative 'datadog_chef_metrics'
+require_relative 'datadog_chef_tags'
+require_relative 'datadog_chef_events'
 
 class Chef
   class Handler
@@ -23,56 +26,44 @@ class Chef
         # use agent proxy settings if available
         use_agent_proxy unless ENV['DATADOG_PROXY'].nil?
 
-        # resolve correct hostname
-        hostname = select_hostname(run_status.node, config)
+        hostname = resolve_correct_hostname(run_status.node, config)
 
         # Send the metrics
-        emit_metrics_to_datadog(hostname, run_status)
+        metrics =
+            DatadogChefMetrics.new
+            .with_dogapi_client(@dog)
+            .for_hostname(hostname)
+            .using_run_status(run_status)
 
-        # Build the correct event
-        event_data = build_event_data(hostname, run_status)
+        # Collect tags
+        tags =
+            DatadogChefTags.new
+            .with_dogapi_client(@dog)
+            .for_hostname(hostname)
+            .for_node(node)
+            .with_application_key(@config[:application_key])
+
+        # Build the event
+        event =
+            DatadogChefEvents.new
+            .with_dogapi_client(@dog)
+            .for_hostname(hostname)
+            .using_run_status(run_status)
+            .with_failure_notifications(@config['notify_on_failure'])
+            .with_tags(tags.combined_host_tags)
 
         # Submit the details back to Datadog
         begin
-          # Collect tags
-          new_host_tags = get_combined_tags(node)
-
-          # Send the Event data
-          emit_event_to_datadog(hostname, event_data, new_host_tags)
-
-          # Update tags
-          if config[:application_key].nil?
-            Chef::Log.warn('You need an application key to let Chef tag your nodes ' \
-              'in Datadog. Visit https://app.datadoghq.com/account/settings#api to ' \
-                'create one and update your datadog attributes in the datadog cookbook.'
-            )
-            fail ArgumentError, 'Missing Datadog Application Key'
-          else
-
-            # Replace all Chef tags with the found Chef tags
-            rc = @dog.update_tags(hostname, new_host_tags, 'chef')
-            begin
-              # See FIXME above about why I feel dirty repeating this code here
-              if rc.length < 2
-                Chef::Log.warn("Unexpected response from Datadog Event API: #{rc}")
-              else
-                if rc[0].to_i / 100 != 2
-                  Chef::Log.warn("Could not submit #{new_host_tags} tags for #{hostname} to Datadog: #{rc}")
-                else
-                  Chef::Log.debug("Successfully updated #{hostname}'s tags to #{new_host_tags.join(', ')}")
-                end
-              end
-            rescue
-              Chef::Log.warn("Could not determine whether #{hostname}'s tags were successfully submitted to Datadog: #{rc}")
-            end
-          end
+          metrics.emit_to_datadog
+          event.emit_to_datadog
+          tags.update_to_datadog
         rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
           Chef::Log.error("Could not connect to Datadog. Connection error:\n" + e)
           Chef::Log.error('Data to be submitted was:')
-          Chef::Log.error(event_title)
-          Chef::Log.error(event_body)
+          Chef::Log.error(event.event_title)
+          Chef::Log.error(event.event_body)
           Chef::Log.error('Tags to be set for this run:')
-          Chef::Log.error(new_host_tags)
+          Chef::Log.error(tags.combined_host_tags)
         end
       ensure
         # restore the env proxy settings before leaving
@@ -81,173 +72,6 @@ class Chef
 
       private
 
-      # Build the Event data for submission
-      #
-      # @param hostname [String] resolved hostname to attach to Event
-      # @param run_status [Chef::RunStatus] current run status
-      # @return [Array] alert_type, event_priority, event_title, event_body
-      def build_event_data(hostname, run_status)
-        # bail early in case of a compiletime failure
-        # OPTIMIZE: Use better inspectors to handle failure scenarios, refactor needed.
-        if run_status.elapsed_time.nil?
-
-          alert_type = 'error'
-          event_title = "Chef failed during compile phase on #{hostname} "
-          event_priority = 'normal'
-          event_body = 'Chef was unable to complete a run, an error during compilation may have occurred.'
-
-          return [alert_type, event_priority, event_title, event_body]
-        end
-
-        run_time = pluralize(run_status.elapsed_time, 'second')
-
-        # This is the first line of the Event body, the rest is appended here.
-        event_body = "Chef updated #{run_status.updated_resources.length} resources out of #{run_status.all_resources.length} resources total."
-
-        # Show the updated resource list, truncated when failed to 5
-        event_body << updated_resource_list(run_status)
-
-        if run_status.success?
-          alert_type = 'success'
-          event_priority = 'low'
-          event_title = "Chef completed in #{run_time} on #{hostname} "
-        else
-          alert_type = 'error'
-          event_priority = 'normal'
-          event_title = "Chef failed in #{run_time} on #{hostname} "
-
-          if @config[:notify_on_failure]
-            handles = @config[:notify_on_failure]
-            # convert the notification handle array to a string
-            event_body << "\nAlerting: #{handles.join(' ')}\n"
-          end
-
-          event_body << "\n$$$\n#{run_status.formatted_exception}\n$$$\n"
-          event_body << "\n$$$\n#{run_status.backtrace.join("\n")}\n$$$\n"
-        end
-
-        # Return resolved data
-        [alert_type, event_priority, event_title, event_body]
-      end
-
-      # Compose a list of resources updated during a run.
-      # Shorten the list when there is a failure for stacktrace debugging
-      #
-      # @param run_status [Chef::RunStatus] current run status
-      # @return [String] formatted list of resources updated, truncated on failure
-      def updated_resource_list(run_status)
-        # No resources updated? Go away.
-        return '' unless run_status.updated_resources.length.to_i > 0
-
-        if run_status.failed?
-          report_resources = run_status.updated_resources.last(5)
-        else
-          report_resources = run_status.updated_resources
-        end
-
-        event_body = "\n$$$\n"
-        report_resources.each do |r|
-          event_body << "- #{r} (#{r.defined_at})\n"
-        end
-        event_body << "\n$$$\n"
-      end
-
-      # Emit Event to Datadog Event Stream
-      #
-      # @param hostname [String] resolved hostname to attach to Event
-      # @param event_params [Array] all the configurables to build a valid Event
-      # @param tags [Array] Chef env/roles/tags to be set as Datadog tags
-      def emit_event_to_datadog(hostname, event_data, tags)
-        alert_type, event_priority, event_title, event_body = event_data
-
-        evt = @dog.emit_event(Dogapi::Event.new(event_body,
-                                                msg_title: event_title,
-                                                event_type: 'config_management.run',
-                                                event_object: hostname,
-                                                alert_type: alert_type,
-                                                priority: event_priority,
-                                                source_type_name: 'chef',
-                                                tags: tags
-        ), host: hostname)
-
-        begin
-          # FIXME: nice-to-have: abstract format of return value away a bit
-          # in dogapi directly. See https://github.com/DataDog/dogapi-rb/issues/18
-          if evt.length < 2
-            Chef::Log.warn("Unexpected response from Datadog Event API: #{evt}")
-          else
-            # [http_response_code, {"event" => {"url" => "...", ...}}]
-            # 2xx means ok
-            if evt[0].to_i / 100 != 2
-              Chef::Log.warn("Could not submit event to Datadog (HTTP call failed): #{evt[0]}")
-            else
-              Chef::Log.debug("Successfully submitted Chef event to Datadog for #{hostname} at #{evt[1]['event']['url']}")
-            end
-          end
-        rescue
-          Chef::Log.warn("Could not determine whether chef run was successfully submitted to Datadog: #{evt}")
-        end
-      end
-
-      # Emit Chef metrics to Datadog
-      #
-      # @param hostname [String] resolved hostname to attach to series
-      # @param run_status [Chef::RunStatus] current run status
-      def emit_metrics_to_datadog(hostname, run_status)
-        # If there is a failure during compile phase, a large portion of
-        # run_status may be unavailable. Bail out here
-        warn_msg = 'Error during compile phase, no Datadog metrics available.'
-        return Chef::Log.warn(warn_msg) if run_status.elapsed_time.nil?
-
-        @dog.emit_point('chef.resources.total', run_status.all_resources.length, host: hostname)
-        @dog.emit_point('chef.resources.updated', run_status.updated_resources.length, host: hostname)
-        @dog.emit_point('chef.resources.elapsed_time', run_status.elapsed_time, host: hostname)
-        Chef::Log.debug('Submitted Chef metrics back to Datadog')
-      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
-        Chef::Log.error("Could not send metrics to Datadog. Connection error:\n" + e)
-      end
-
-      # Build up an array of Chef tags to send back
-      #
-      # Selects all [env, roles, tags] from the Node's object and reformats
-      # them to `key:value` e.g. `role:database-master`.
-      #
-      # @param node [Chef::Node]
-      # @return [Array] current Chef env, roles, tags
-      def get_combined_tags(node)
-        chef_env = get_node_env(node).split # converts a string into an array
-
-        chef_roles = get_node_roles(node)
-        chef_tags = get_node_tags(node)
-
-        # Combine (union) all arrays. Removes duplicates if found.
-        chef_env | chef_roles | chef_tags
-      end
-
-      def get_node_roles(node)
-        node.run_list.roles.map! { |role| 'role:' + role }
-      end
-
-      def get_node_env(node)
-        'env:' + node.chef_environment if node.respond_to?('chef_environment')
-      end
-
-      def get_node_tags(node)
-        node.tags.map! { |tag| 'tag:' + tag }
-      end
-
-      def pluralize(number, noun)
-        case number
-        when 0..1
-          "less than 1 #{noun}"
-        else
-          "#{number.round} #{noun}s"
-        end
-      rescue
-        Chef::Log.warn("Cannot make #{number} more legible")
-        "#{number} #{noun}s"
-      end
-
       # Select which hostname to report back to Datadog.
       # Makes decision based on inputs from `config` and when absent, use the
       # node's `ec2` attribute existence to make the decision.
@@ -255,7 +79,7 @@ class Chef
       # @param node [Chef::Node] from `run_status`, can feasibly any `node`
       # @param config [Hash] config object passed in to handler
       # @return [String] the hostname decided upon
-      def select_hostname(node, config)
+      def resolve_correct_hostname(node, config)
         use_ec2_instance_id = !config.key?(:use_ec2_instance_id) ||
                               (config.key?(:use_ec2_instance_id) && config[:use_ec2_instance_id])
 
@@ -269,10 +93,10 @@ class Chef
       end
 
       # Using the agent proxy settings requires setting http(s)_proxy
-      # env vars.  However, original env var settings need to be 
+      # env vars.  However, original env var settings need to be
       # preserved for restoration at the end of the handler.
       def use_agent_proxy
-        Chef::Log.info("Using agent proxy settings")
+        Chef::Log.info('Using agent proxy settings')
         @env_http_proxy = ENV['http_proxy']
         @env_https_proxy = ENV['https_proxy']
         ENV['http_proxy'] = ENV['DATADOG_PROXY']

--- a/lib/chef/handler/datadog_chef_events.rb
+++ b/lib/chef/handler/datadog_chef_events.rb
@@ -4,6 +4,7 @@ require 'chef/handler'
 require 'chef/mash'
 require 'dogapi'
 
+# helper class for sending events about chef runs
 class DatadogChefEvents
   def initialize
     @dog = nil
@@ -14,38 +15,57 @@ class DatadogChefEvents
     @alert_type = ''
     @event_priority = ''
     @event_title = ''
+    # TODO: refactor how event_body is constructed in the class methods
+    #       handling of the event_body is a bit clunky and depends on the order of
+    #       method calls
     @event_body = ''
   end
-
-  def and
-    self
-  end
-
+  # set the dogapi client handle
+  #
+  # @param dogapi_client [Dogapi::Client] datadog api client handle
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
   def with_dogapi_client(dogapi_client)
     @dog = dogapi_client
     self
   end
 
-  def for_hostname(hostname)
+  # set the target hostname (chef node name)
+  #
+  # @param hostname [String] hostname to use for the handler report
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_hostname(hostname)
     @hostname = hostname
     self
   end
 
-  def using_run_status(run_status)
+  # set the chef run status used for the report
+  #
+  # @param run_status [Chef::RunStatus] current chef run status
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_run_status(run_status)
     @run_status = run_status
     self
   end
 
+  # set the failure notification list
+  #
+  # @param failure_notifications [Array] set of datadog notification handles
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
   def with_failure_notifications(failure_notifications)
     @failure_notifications = failure_notifications
     self
   end
 
+  # set the datadog host tags associated with the event
+  #
+  # @param [Array] the set of host tags
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
   def with_tags(tags)
     @tags = tags
     self
   end
 
+  # Emit Chef event to Datadog
   def emit_to_datadog
     @event_body = ''
     build_event_data
@@ -82,42 +102,36 @@ class DatadogChefEvents
 
   def pluralize(number, noun)
     case number
-      when 0..1
-        "less than 1 #{noun}"
-      else
-        "#{number.round} #{noun}s"
+    when 0..1
+      "less than 1 #{noun}"
+    else
+      "#{number.round} #{noun}s"
     end
   rescue
     Chef::Log.warn("Cannot make #{number} more legible")
     "#{number} #{noun}s"
   end
 
+  # Compose a list of resources updated during a run.
   def update_resource_list
-    # Compose a list of resources updated during a run.
-    # Shorten the list when there is a failure for stacktrace debugging
-    # No resources updated? set an empty event_body
+    # No resources updated?
+    return unless @run_status.updated_resources.length.to_i > 0
 
-    if @run_status.updated_resources.length.to_i > 0
-      if @run_status.failed?
-        report_resources = @run_status.updated_resources.last(5)
-      else
-        report_resources = @run_status.updated_resources
-      end
-
-      @event_body = "\n$$$\n"
-      report_resources.each do |r|
-        @event_body << "- #{r} (#{r.defined_at})\n"
-      end
-      @event_body << "\n$$$\n"
+    if @run_status.failed?
+      # Shorten the list when there is a failure for stacktrace debugging
+      report_resources = @run_status.updated_resources.last(5)
+    else
+      report_resources = @run_status.updated_resources
     end
+
+    @event_body = "\n$$$\n"
+    report_resources.each do |r|
+      @event_body << "- #{r} (#{r.defined_at})\n"
+    end
+    @event_body << "\n$$$\n"
   end
 
-  # Build the Event data for submission
-  #
-  # @param hostname [String] resolved hostname to attach to Event
-  # @param run_status [Chef::RunStatus] current run status
-  # @param notify_on_failure [Array] array of notification handles
-  # @return [Array] alert_type, event_priority, event_title, event_body
+  # Marshal the Event data for submission
   def build_event_data
     # bail early in case of a compiletime failure
     # OPTIMIZE: Use better inspectors to handle failure scenarios, refactor needed.
@@ -132,8 +146,8 @@ class DatadogChefEvents
       # This is the first line of the Event body, the rest is appended here.
       @event_body = "Chef updated #{@run_status.updated_resources.length} resources out of #{@run_status.all_resources.length} resources total."
 
-      # Show the updated resource list, truncated when failed to 5
-      # @event_body << updated_resource_list
+      # Update resource list, truncated when failed to 5
+      # update will add to the event_body
       update_resource_list
 
       if @run_status.success?

--- a/lib/chef/handler/datadog_chef_events.rb
+++ b/lib/chef/handler/datadog_chef_events.rb
@@ -1,0 +1,159 @@
+# encoding: utf-8
+require 'rubygems'
+require 'chef/handler'
+require 'chef/mash'
+require 'dogapi'
+
+class DatadogChefEvents
+  def initialize
+    @dog = nil
+    @hostname = nil
+    @run_status = nil
+    @failure_notfications = nil
+
+    @alert_type = ''
+    @event_priority = ''
+    @event_title = ''
+    @event_body = ''
+  end
+
+  def and
+    self
+  end
+
+  def with_dogapi_client(dogapi_client)
+    @dog = dogapi_client
+    self
+  end
+
+  def for_hostname(hostname)
+    @hostname = hostname
+    self
+  end
+
+  def using_run_status(run_status)
+    @run_status = run_status
+    self
+  end
+
+  def with_failure_notifications(failure_notifications)
+    @failure_notifications = failure_notifications
+    self
+  end
+
+  def with_tags(tags)
+    @tags = tags
+    self
+  end
+
+  def emit_to_datadog
+    @event_body = ''
+    build_event_data
+    evt = @dog.emit_event(Dogapi::Event.new(@event_body,
+                                            msg_title: @event_title,
+                                            event_type: 'config_management.run',
+                                            event_object: @hostname,
+                                            alert_type: @alert_type,
+                                            priority: @event_priority,
+                                            source_type_name: 'chef',
+                                            tags: @tags
+    ), host: @hostname)
+
+    begin
+      # FIXME: nice-to-have: abstract format of return value away a bit
+      # in dogapi directly. See https://github.com/DataDog/dogapi-rb/issues/18
+      if evt.length < 2
+        Chef::Log.warn("Unexpected response from Datadog Event API: #{evt}")
+      else
+        # [http_response_code, {"event" => {"url" => "...", ...}}]
+        # 2xx means ok
+        if evt[0].to_i / 100 != 2
+          Chef::Log.warn("Could not submit event to Datadog (HTTP call failed): #{evt[0]}")
+        else
+          Chef::Log.debug("Successfully submitted Chef event to Datadog for #{@hostname} at #{evt[1]['event']['url']}")
+        end
+      end
+    rescue
+      Chef::Log.warn("Could not determine whether chef run was successfully submitted to Datadog: #{evt}")
+    end
+  end
+
+  private
+
+  def pluralize(number, noun)
+    case number
+      when 0..1
+        "less than 1 #{noun}"
+      else
+        "#{number.round} #{noun}s"
+    end
+  rescue
+    Chef::Log.warn("Cannot make #{number} more legible")
+    "#{number} #{noun}s"
+  end
+
+  def update_resource_list
+    # Compose a list of resources updated during a run.
+    # Shorten the list when there is a failure for stacktrace debugging
+    # No resources updated? set an empty event_body
+
+    if @run_status.updated_resources.length.to_i > 0
+      if @run_status.failed?
+        report_resources = @run_status.updated_resources.last(5)
+      else
+        report_resources = @run_status.updated_resources
+      end
+
+      @event_body = "\n$$$\n"
+      report_resources.each do |r|
+        @event_body << "- #{r} (#{r.defined_at})\n"
+      end
+      @event_body << "\n$$$\n"
+    end
+  end
+
+  # Build the Event data for submission
+  #
+  # @param hostname [String] resolved hostname to attach to Event
+  # @param run_status [Chef::RunStatus] current run status
+  # @param notify_on_failure [Array] array of notification handles
+  # @return [Array] alert_type, event_priority, event_title, event_body
+  def build_event_data
+    # bail early in case of a compiletime failure
+    # OPTIMIZE: Use better inspectors to handle failure scenarios, refactor needed.
+    if @run_status.elapsed_time.nil?
+      @alert_type = 'error'
+      @event_title = "Chef failed during compile phase on #{@hostname} "
+      @event_priority = 'normal'
+      @event_body = 'Chef was unable to complete a run, an error during compilation may have occurred.'
+    else
+      run_time = pluralize(@run_status.elapsed_time, 'second')
+
+      # This is the first line of the Event body, the rest is appended here.
+      @event_body = "Chef updated #{@run_status.updated_resources.length} resources out of #{@run_status.all_resources.length} resources total."
+
+      # Show the updated resource list, truncated when failed to 5
+      # @event_body << updated_resource_list
+      update_resource_list
+
+      if @run_status.success?
+        @alert_type = 'success'
+        @event_priority = 'low'
+        @event_title = "Chef completed in #{run_time} on #{@hostname} "
+      else
+        @alert_type = 'error'
+        @event_priority = 'normal'
+        @event_title = "Chef failed in #{run_time} on #{@hostname} "
+
+        if @failure_notifications
+          handles = @failure_notifications
+          # convert the notification handle array to a string
+          @event_body << "\nAlerting: #{handles.join(' ')}\n"
+        end
+
+        @event_body << "\n$$$\n#{@run_status.formatted_exception}\n$$$\n"
+        @event_body << "\n$$$\n#{@run_status.backtrace.join("\n")}\n$$$\n"
+      end
+    end
+  end
+end # end module DatadogChefEvent

--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -1,0 +1,48 @@
+# encoding: utf-8
+require 'dogapi'
+
+# helper class for sending datadog metrics from a chef run
+class DatadogChefMetrics
+  def initialize
+    @dog = nil
+    @hostname = ''
+    @run_status = nil
+  end
+
+  def and
+    self
+  end
+
+  # @param dogapi_client [Dogapi::Client] datadog api client
+  def with_dogapi_client(dogapi_client)
+    @dog = dogapi_client
+    self
+  end
+
+  # @param hostname [String] hostname used for reporting metrics
+  def for_hostname(hostname)
+    @hostname = hostname
+    self
+  end
+
+  # @param run_status [Chef::RunStatus] current run status
+  def using_run_status(run_status)
+    @run_status = run_status
+    self
+  end
+
+  # Emit Chef metrics to Datadog
+  def emit_to_datadog
+    # If there is a failure during compile phase, a large portion of
+    # run_status may be unavailable. Bail out here
+    warn_msg = 'Error during compile phase, no Datadog metrics available.'
+    return Chef::Log.warn(warn_msg) if @run_status.elapsed_time.nil?
+
+    @dog.emit_point('chef.resources.total', @run_status.all_resources.length, host: @hostname)
+    @dog.emit_point('chef.resources.updated', @run_status.updated_resources.length, host: @hostname)
+    @dog.emit_point('chef.resources.elapsed_time', @run_status.elapsed_time, host: @hostname)
+    Chef::Log.debug('Submitted Chef metrics back to Datadog')
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
+    Chef::Log.error("Could not send metrics to Datadog. Connection error:\n" + e)
+  end
+end # end class DatadogChefMetrics

--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -9,24 +9,29 @@ class DatadogChefMetrics
     @run_status = nil
   end
 
-  def and
-    self
-  end
-
+  # set the dogapi client handle
+  #
   # @param dogapi_client [Dogapi::Client] datadog api client
+  # @return [DatadogChefMetrics] instance reference to self enabling method chaining
   def with_dogapi_client(dogapi_client)
     @dog = dogapi_client
     self
   end
 
+  # set the target hostname (chef node name)
+  #
   # @param hostname [String] hostname used for reporting metrics
-  def for_hostname(hostname)
+  # @return [DatadogChefMetrics] instance reference to self enabling method chaining
+  def with_hostname(hostname)
     @hostname = hostname
     self
   end
 
+  # set the chef run status used for the report
+  #
   # @param run_status [Chef::RunStatus] current run status
-  def using_run_status(run_status)
+  # @return [DatadogChefMetrics] instance reference to self enabling method chaining
+  def with_run_status(run_status)
     @run_status = run_status
     self
   end

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -6,25 +6,37 @@ require 'dogapi'
 
 # helper class for sending datadog tags from chef runs
 class DatadogChefTags
-  def initialize(node = nil)
-    @node = node
+  def initialize
+    @node = nil
+    @run_status = nil
     @application_key = nil
     @combined_host_tags = nil
   end
 
-  def and
-    self
-  end
-
+  # set the dogapi client handle
+  #
+  # @param dogapi_client [Dogapi::Client] datadog api client handle
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
   def with_dogapi_client(dogapi_client)
     @dog = dogapi_client
     self
   end
 
-  # @param node [Chef::Node]
-  # @return [DatadogChefTags]
-  def for_node(node)
-    @node = node
+  # attribute accessor for combined array of tags
+  #
+  # @return [Array] the set of host tags based off the chef run
+  attr_reader :combined_host_tags
+
+  # set the chef run status used for the report
+  #
+  # @param run_status [Chef::RunStatus] current chef run status
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_run_status(run_status)
+    @run_status = run_status
+    # Build up an array of Chef tags that will be sent back
+    # Selects all [env, roles, tags] from the Node's object and reformats
+    # them to `key:value` e.g. `role:database-master`.
+    @node = run_status.node
     # generate the combined tags
     chef_env = node_env.split # converts a string into an array
     chef_roles = node_roles
@@ -35,11 +47,23 @@ class DatadogChefTags
     self
   end
 
-  def for_hostname(hostname)
+  # set the target hostname (chef node name)
+  #
+  # @param hostname [String] hostname to use for the handler report
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_hostname(hostname)
     @hostname = hostname
     self
   end
 
+  # set the datadog application key
+  #
+  # TODO: the application key is only needed for error checking, e.g. an app key exists
+  #   would be cleaner to push this check up to the data prep method in the
+  #   calling handler class
+  #
+  # @param application_key [String] datadog application key used for chef reports
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
   def with_application_key(application_key)
     @application_key = application_key
     if @application_key.nil?
@@ -52,18 +76,8 @@ class DatadogChefTags
     self
   end
 
-  # Build up an array of Chef tags to send back
-  #
-  # Selects all [env, roles, tags] from the Node's object and reformats
-  # them to `key:value` e.g. `role:database-master`.
-  # @return [Array] current Chef env, roles, tags
-  attr_reader :combined_host_tags
-  # def combined_host_tags
-  #   @combined_host_tags
-  # end
-
-  # Replace all Chef tags with the found Chef tags
-  def update_to_datadog
+  # send updated chef run generated tags to Datadog
+  def send_update_to_datadog
     rc = @dog.update_tags(@hostname, combined_host_tags, 'chef')
     begin
       # See FIXME above about why I feel dirty repeating this code here
@@ -94,4 +108,4 @@ class DatadogChefTags
   def node_tags
     @node.tags.map! { |tag| 'tag:' + tag }
   end
-end
+end # end class DatadogChefTags

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -1,0 +1,97 @@
+# encoding: utf-8
+require 'rubygems'
+require 'chef/handler'
+require 'chef/mash'
+require 'dogapi'
+
+# helper class for sending datadog tags from chef runs
+class DatadogChefTags
+  def initialize(node = nil)
+    @node = node
+    @application_key = nil
+    @combined_host_tags = nil
+  end
+
+  def and
+    self
+  end
+
+  def with_dogapi_client(dogapi_client)
+    @dog = dogapi_client
+    self
+  end
+
+  # @param node [Chef::Node]
+  # @return [DatadogChefTags]
+  def for_node(node)
+    @node = node
+    # generate the combined tags
+    chef_env = node_env.split # converts a string into an array
+    chef_roles = node_roles
+    chef_tags = node_tags
+
+    # Combine (union) all arrays. Removes duplicates if found.
+    @combined_host_tags = chef_env | chef_roles | chef_tags
+    self
+  end
+
+  def for_hostname(hostname)
+    @hostname = hostname
+    self
+  end
+
+  def with_application_key(application_key)
+    @application_key = application_key
+    if @application_key.nil?
+      Chef::Log.warn('You need an application key to let Chef tag your nodes ' \
+              'in Datadog. Visit https://app.datadoghq.com/account/settings#api to ' \
+                'create one and update your datadog attributes in the datadog cookbook.'
+      )
+      fail ArgumentError, 'Missing Datadog Application Key'
+    end
+    self
+  end
+
+  # Build up an array of Chef tags to send back
+  #
+  # Selects all [env, roles, tags] from the Node's object and reformats
+  # them to `key:value` e.g. `role:database-master`.
+  # @return [Array] current Chef env, roles, tags
+  attr_reader :combined_host_tags
+  # def combined_host_tags
+  #   @combined_host_tags
+  # end
+
+  # Replace all Chef tags with the found Chef tags
+  def update_to_datadog
+    rc = @dog.update_tags(@hostname, combined_host_tags, 'chef')
+    begin
+      # See FIXME above about why I feel dirty repeating this code here
+      if rc.length < 2
+        Chef::Log.warn("Unexpected response from Datadog Event API: #{rc}")
+      else
+        if rc[0].to_i / 100 != 2
+          Chef::Log.warn("Could not submit #{combined_host_tags} tags for #{@hostname} to Datadog: #{rc}")
+        else
+          Chef::Log.debug("Successfully updated #{@hostname}'s tags to #{combined_host_tags.join(', ')}")
+        end
+      end
+    rescue
+      Chef::Log.warn("Could not determine whether #{@hostname}'s tags were successfully submitted to Datadog: #{rc}")
+    end
+  end
+
+  private
+
+  def node_roles
+    @node.run_list.roles.map! { |role| 'role:' + role }
+  end
+
+  def node_env
+    'env:' + @node.chef_environment if @node.respond_to?('chef_environment')
+  end
+
+  def node_tags
+    @node.tags.map! { |tag| 'tag:' + tag }
+  end
+end


### PR DESCRIPTION
2 part change to both the chef-handler-datadog project and the dd-handler.rb recipe in the chef-datadog cookbook.  
This pull request resolves issue #64.

While both changes are needed to activate the feature, both project code bases can function independently.  The feature will remain dormant until both changes are merged and packaged.

The cookbook pull request adds a new env var containing the agent proxy details.
The handler pull request stores the initial http(s) env variables, then sets them for the report run.  At the end of the report run, the original proxy env variables are restored. 
This pull request adds the a