### PR TITLE
Test node.tags before calling map!

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -227,7 +227,7 @@ class Chef
       end
 
       def get_node_tags(node)
-        node.tags.map! { |tag| 'tag:' + tag }
+        node.tags.map! { |tag| 'tag:' + tag } if node.tags
       end
 
       def pluralize(number, noun)


### PR DESCRIPTION
If a node has no tags, get_node_tags causes a compile-time exception that stops the Chef run in its tracks.

We might need a change in get_node_roles as well.