### PR TITLE
Retry tags' submission when host is not yet present on DD

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -55,6 +55,7 @@ class Chef
             .with_hostname(hostname)
             .with_run_status(run_status)
             .with_application_key(config[:application_key])
+            .with_retries(@config[:tags_submission_retries])
 
         # Build the chef event information
         @event =

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -233,6 +233,76 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
     end
   end
 
+  context 'tags submission retries' do
+    before(:each) do
+      @node = Chef::Node.build('chef.handler.datadog.test-tags-retries')
+
+      @node.send(:chef_environment, 'hostile')
+      @node.send(:run_list, 'role[highlander]')
+      @node.normal.tags = ['the_one_and_only']
+
+      @events = Chef::EventDispatch::Dispatcher.new
+      @run_context = Chef::RunContext.new(@node, {}, @events)
+      @run_status = Chef::RunStatus.new(@node, @events)
+
+      @expected_time = Time.now
+      allow(Time).to receive(:now).and_return(@expected_time, @expected_time + 5)
+      @run_status.start_clock
+      @run_status.stop_clock
+
+      @run_status.run_context = @run_context
+    end
+
+    describe 'when specified as 2 retries' do
+      before(:each) do
+        @handler.config[:tags_submission_retries] = 2
+        # Stub `sleep` to avoid slowing down the execution
+        allow_any_instance_of(DatadogChefTags).to receive(:sleep)
+      end
+
+      it 'retries no more than twice' do
+        @handler.run_report_unsafe(@run_status)
+
+        expect(a_request(:put, HOST_TAG_ENDPOINT + @node.name).with(
+          :query => { 'api_key' => @handler.config[:api_key],
+                      'application_key' => @handler.config[:application_key],
+                      'source' => 'chef' },
+          :body => hash_including(:tags => [
+            'env:hostile', 'role:highlander', 'tag:the_one_and_only'
+            ]),
+        )).to have_been_made.times(3)
+      end
+
+      it 'stops retrying once submission is successful' do
+        @handler.run_report_unsafe(@run_status)
+
+        expect(a_request(:put, HOST_TAG_ENDPOINT + @node.name).with(
+          :query => { 'api_key' => @handler.config[:api_key],
+                      'application_key' => @handler.config[:application_key],
+                      'source' => 'chef' },
+          :body => hash_including(:tags => [
+            'env:hostile', 'role:highlander', 'tag:the_one_and_only'
+            ]),
+        )).to have_been_made.times(2)
+      end
+    end
+
+    describe 'when not specified' do
+      it 'does not retry after a failed submission'  do
+        @handler.run_report_unsafe(@run_status)
+
+        expect(a_request(:put, HOST_TAG_ENDPOINT + @node.name).with(
+          :query => { 'api_key' => @handler.config[:api_key],
+                      'application_key' => @handler.config[:application_key],
+                      'source' => 'chef' },
+          :body => hash_including(:tags => [
+            'env:hostile', 'role:highlander', 'tag:the_one_and_only'
+            ]),
+        )).to have_been_made.times(1)
+      end
+    end
+  end
+
   describe 'handles no application_key' do
     before(:each) do
       @node = Chef::Node.build('chef.handler.datadog.test-noapp')

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_not_specified/does_not_retry_after_a_failed_submission.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_not_specified/does_not_retry_after_a_failed_submission.yml
@@ -1,0 +1,249 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:21 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:22 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1428248966,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1428248966,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-tags-retries","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '420'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1428248966,
+        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-tags
+        ", "url": "https://app.datadoghq.com/event/event?id=2751230185062799345",
+        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"], "related_event_id": null, "id":
+        2751230185062799345}}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+recorded_with: VCR 2.9.3

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_specified_as_2_retries/retries_no_more_than_twice.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_specified_as_2_retries/retries_no_more_than_twice.yml
@@ -1,0 +1,294 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:21 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:22 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1428248966,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1428248966,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-tags-retries","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '420'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1428248966,
+        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-tags
+        ", "url": "https://app.datadoghq.com/event/event?id=2751230185062799345",
+        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"], "related_event_id": null, "id":
+        2751230185062799345}}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+recorded_with: VCR 2.9.3

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_specified_as_2_retries/stops_retrying_once_submission_is_successful.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags_submission_retries/when_specified_as_2_retries/stops_retrying_once_submission_is_successful.yml
@@ -1,0 +1,250 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:21 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:22 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1428248966,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags-retries","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok"}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1428248966,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-tags-retries","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json; charset=UTF-8
+      Date:
+      - Sun, 05 Apr 2015 15:49:23 GMT
+      Server:
+      - dogdispatcher/6.1.23
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Content-Length:
+      - '420'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1428248966,
+        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-tags
+        ", "url": "https://app.datadoghq.com/event/event?id=2751230185062799345",
+        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"], "related_event_id": null, "id":
+        2751230185062799345}}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '44'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["No host matches that host_id"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags-retries?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 05 Apr 2015 15:49:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Dd-Debug:
+      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '110'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"]}'
+    http_version:
+  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
By default, doesn't retry submitting tags.

`tags_submission_retries` can be set to a non-zero value so that the
tags' submission is retried when the host doesn't exist yet (= 404
status code from the API), which happens on the initial run of the
handler.

Solves #67