### PR TITLE
allow selecitve reporting via configuration

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -68,9 +68,9 @@ class Chef
 
       # Submit metrics, event, and tags information to datadog
       def send_report_to_datadog
-        @metrics.emit_to_datadog
-        @event.emit_to_datadog
-        @tags.send_update_to_datadog
+        @metrics.emit_to_datadog unless @config[:skip_metrics]
+        @event.emit_to_datadog unless @config[:skip_events]
+        @tags.send_update_to_datadog unless @config[:skip_update_tags]
       rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
         Chef::Log.error("Could not connect to Datadog. Connection error:\n" + e)
         Chef::Log.error('Data to be submitted was:')

--- a/lib/chef_handler_datadog.rb
+++ b/lib/chef_handler_datadog.rb
@@ -2,5 +2,5 @@
 # Helper module for version number only.
 # Real deal in 'chef/handler/datadog.rb'
 module ChefHandlerDatadog
-  VERSION = '0.8.0.dev'
+  VERSION = '0.8.1.dev'
 end


### PR DESCRIPTION
This is to allow selective configurable functionality. It would require changes to dd-reporter in the chef-datadog cookbook, but this is a first step for it.
