### PR TITLE
batch metrics and add more detailed stats

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -12,6 +12,7 @@ class Chef
     # Datadog handler to send Chef run details to Datadog
     class Datadog < Chef::Handler
       attr_reader :config
+      attr_reader :metrics
 
       # For the tags to work, the client must have created an Application Key on the
       # "Account Settings" page here: https://app.datadoghq.com/account/settings

--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -3,10 +3,13 @@ require 'dogapi'
 
 # helper class for sending datadog metrics from a chef run
 class DatadogChefMetrics
+  attr_reader :details
+
   def initialize
     @dog = nil
     @hostname = ''
     @run_status = nil
+    @details = []
   end
 
   # set the dogapi client handle
@@ -43,11 +46,34 @@ class DatadogChefMetrics
     warn_msg = 'Error during compile phase, no Datadog metrics available.'
     return Chef::Log.warn(warn_msg) if @run_status.elapsed_time.nil?
 
-    @dog.emit_point('chef.resources.total', @run_status.all_resources.length, host: @hostname)
-    @dog.emit_point('chef.resources.updated', @run_status.updated_resources.length, host: @hostname)
-    @dog.emit_point('chef.resources.elapsed_time', @run_status.elapsed_time, host: @hostname)
+    @dog.batch_metrics do
+      collect_detailed_resource_metrics
+      @details.each do |m|
+        @dog.emit_point(m[:name], m[:value], host: @hostname, tags: m[:tags])
+      end
+      @dog.emit_point('chef.resources.total', @run_status.all_resources.length, host: @hostname)
+      @dog.emit_point('chef.resources.updated', @run_status.updated_resources.length, host: @hostname)
+      @dog.emit_point('chef.resources.elapsed_time', @run_status.elapsed_time, host: @hostname)
+    end
     Chef::Log.debug('Submitted Chef metrics back to Datadog')
   rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
     Chef::Log.error("Could not send metrics to Datadog. Connection error:\n" + e)
+  end
+
+  private
+
+  # collect all resource metrics from the @run_status
+  def collect_detailed_resource_metrics
+    @details = @run_status.all_resources.each_with_object([]) do |resource, resource_metrics|
+      resource_metric_tags = {
+        resource_name:     resource.name,
+        cookbook:          resource.cookbook_name,
+        recipe:            resource.recipe_name
+      }
+
+      resource_metrics << { name: 'chef.resources.convergence_time',
+                            tags: resource_metric_tags.map { |k, v| "#{k}:#{v}" }.join(' '),
+                            value: resource.elapsed_time }
+    end
   end
 end # end class DatadogChefMetrics

--- a/lib/chef_handler_datadog.rb
+++ b/lib/chef_handler_datadog.rb
@@ -2,5 +2,5 @@
 # Helper module for version number only.
 # Real deal in 'chef/handler/datadog.rb'
 module ChefHandlerDatadog
-  VERSION = '0.8.0.dev'
+  VERSION = '0.8.2.dev'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ require 'rspec'
 require 'vcr'
 require 'webmock/rspec'
 
+# need a fake resource for mocking the result_set via Chef::ResourceBuilder
+require 'chef/resource/package'
+
 # Include our code
 require 'chef/handler/datadog'
 


### PR DESCRIPTION
This is addressing issue of multiple calls made to the metrics api (3) mentioned here:
https://github.com/DataDog/chef-handler-datadog/issues/42

At the same time it pulls more details about the chef run allowing for introspection into resource convergence.