### PR TITLE
Success fail metrics

### DIFF
--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -39,7 +39,7 @@ class DatadogChefMetrics
   # Emit Chef metrics to Datadog
   def emit_to_datadog
     # Send base success/failure metric
-    @dog.emit_point(@run_status.success? ? 'chef.run.success' : 'chef.run.failure', 1, host: @hostname)
+    @dog.emit_point(@run_status.success? ? 'chef.run.success' : 'chef.run.failure', 1, host: @hostname, type: 'counter')
 
     # If there is a failure during compile phase, a large portion of
     # run_status may be unavailable. Bail out here

--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -38,6 +38,9 @@ class DatadogChefMetrics
 
   # Emit Chef metrics to Datadog
   def emit_to_datadog
+    # Send base success/failure metric
+    @dog.emit_point(@run_status.success? ? 'chef.run.success' : 'chef.run.failure', 1, host: @hostname)
+
     # If there is a failure during compile phase, a large portion of
     # run_status may be unavailable. Bail out here
     warn_msg = 'Error during compile phase, no Datadog metrics available.'

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -56,7 +56,7 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
       it 'reports metrics' do
         expect(a_request(:post, METRICS_ENDPOINT).with(
           :query => { 'api_key' => @handler.config[:api_key] }
-        )).to have_been_made.times(3)
+        )).to have_been_made.times(4)
       end
     end
 
@@ -373,10 +373,10 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
         @handler.run_report_unsafe(@run_status)
       end
 
-      it 'does not emit metrics' do
+      it 'only emits a failure metric' do
         expect(a_request(:post, METRICS_ENDPOINT).with(
           :query => { 'api_key' => @handler.config[:api_key] }
-        )).to_not have_been_made
+        )).to have_been_made.times(1)
       end
 
       it 'posts an event' do
@@ -387,7 +387,7 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
         )).to have_been_made.times(1)
       end
     end
-  end
+  end 
 
     # TODO: test failures:
     # @run_status.exception = Exception.new('Boy howdy!')

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_alert_handles_when_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_alert_handles_when_specified.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -104,7 +104,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264911,"msg_title":"Chef
@@ -116,7 +116,7 @@ http_interactions:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -138,8 +138,8 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "normal", "date_happened":
-        1410264911, "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
+      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264911,
+        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507845826654380",
         "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
@@ -154,10 +154,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -183,7 +183,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
@@ -192,10 +192,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -225,10 +225,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -250,7 +250,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -258,10 +258,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -283,7 +283,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
 - request:
@@ -291,7 +291,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\nAlerting:
         @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction: Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264911,"msg_title":"Chef
@@ -303,7 +303,7 @@ http_interactions:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -325,8 +325,8 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "normal", "date_happened":
-        1410264911, "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
+      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264911,
+        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507892182102265",
         "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
@@ -341,10 +341,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"]}'
+      string: '{"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -370,8 +370,86 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-failed", "tags": ["tag:tag:the_one_and_only",
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["tag:tag:the_one_and_only",
         "env:hostile", "role:highlander"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1452809600,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:18 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809600,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:19 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_alert_handles_when_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_alert_handles_when_specified.yml
@@ -5,8 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1453838668,1.0]],"type":"counter","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -19,27 +21,33 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:09 GMT
-      Server:
-      - dogdispatcher/5.2.0
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838668,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -52,27 +60,33 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:09 GMT
-      Server:
-      - dogdispatcher/5.1.1
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838668,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -85,36 +99,80 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:10 GMT
-      Server:
-      - dogdispatcher/5.1.1
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838668,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"\n$$$\n- [paws] (dynamically defined)\n- [ears] (dynamically
+        defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically defined)\n-
+        [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838668,"msg_title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264911,"msg_title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"Chef updated
-        6 resources out of 6 resources total.\n$$$\n- [paws] (dynamically defined)\n-
-        [ears] (dynamically defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically
-        defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -127,28 +185,28 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/plain; charset=utf-8
       Date:
-      - Tue, 09 Sep 2014 12:15:11 GMT
-      Server:
-      - dogdispatcher/5.2.0
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '729'
+      - '647'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264911,
-        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507845826654380",
-        "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236694692316426,"title":"Chef failed
+        in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n",
-        "tags": ["env:hostile", "role:highlander", "tag:the_one_and_only"], "related_event_id":
-        null, "id": 2449507845826654380}}'
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838668,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236694692316426"}}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
@@ -156,6 +214,8 @@ http_interactions:
       encoding: UTF-8
       string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -172,28 +232,38 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Sep 2014 12:15:11 GMT
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - dogweb_sameorig
       Pragma:
       - no-cache
-      Server:
-      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 4G6DflkbLuEPHPN7r5QLLJW1+B1YXxXufb+VXQ5hU44=
+      X-Frame-Options:
+      - SAMEORIGIN
       Content-Length:
       - '112'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1453838668,1.0]],"type":"counter","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -206,27 +276,33 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:12 GMT
-      Server:
-      - dogdispatcher/5.1.1
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264911,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838668,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -239,27 +315,33 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:12 GMT
-      Server:
-      - dogdispatcher/5.1.1
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264911,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838668,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -272,36 +354,80 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Tue, 09 Sep 2014 12:15:13 GMT
-      Server:
-      - dogdispatcher/5.1.1
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
+      encoding: UTF-8
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838668,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"\n$$$\n- [paws] (dynamically defined)\n- [ears] (dynamically
+        defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically defined)\n-
+        [fur] (dynamically defined)\n\n$$$\n\nAlerting: @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838668,"msg_title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\nAlerting:
-        @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction: Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264911,"msg_title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"Chef updated
-        6 resources out of 6 resources total.\n$$$\n- [paws] (dynamically defined)\n-
-        [ears] (dynamically defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically
-        defined)\n- [fur] (dynamically defined)\n\n$$$\n\nAlerting: @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
+        @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction: Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -314,28 +440,28 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/plain; charset=utf-8
       Date:
-      - Tue, 09 Sep 2014 12:15:13 GMT
-      Server:
-      - dogdispatcher/5.2.0
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '758'
+      - '676'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264911,
-        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507892182102265",
-        "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236701686654829,"title":"Chef failed
+        in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\nAlerting:
-        @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction: Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n",
-        "tags": ["env:hostile", "role:highlander", "tag:tag:the_one_and_only"], "related_event_id":
-        null, "id": 2449507892182102265}}'
+        @alice @bob\n\n$$$\nChef::Exceptions::UnsupportedAction: Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838668,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236701686654829"}}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
@@ -343,6 +469,8 @@ http_interactions:
       encoding: UTF-8
       string: '{"tags":["env:hostile","role:highlander","tag:tag:the_one_and_only"]}'
     headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -359,97 +487,27 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Sep 2014 12:15:14 GMT
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - dogweb_sameorig
       Pragma:
       - no-cache
-      Server:
-      - gunicorn/19.1.0
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - QKcGho/VVHvOvAFq4WeaqBhqhL8eYL3K9CW+TToIP+o=
+      X-Frame-Options:
+      - SAMEORIGIN
       Content-Length:
       - '116'
       Connection:
       - keep-alive
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: '{"host": "chef.handler.datadog.test-failed", "tags": ["tag:tag:the_one_and_only",
         "env:hostile", "role:highlander"]}'
     http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:11 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1452809600,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json
-      Date:
-      - Thu, 14 Jan 2016 22:13:18 GMT
-      Dd-Pool:
-      - propjoe
-      Strict-Transport-Security:
-      - max-age=15724800;
-      X-Content-Type-Options:
-      - nosniff
-      Content-Length:
-      - '16'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"status": "ok"}'
-    http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809600,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json
-      Date:
-      - Thu, 14 Jan 2016 22:13:19 GMT
-      Dd-Pool:
-      - propjoe
-      Strict-Transport-Security:
-      - max-age=15724800;
-      X-Content-Type-Options:
-      - nosniff
-      Content-Length:
-      - '16'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"status": "ok"}'
-    http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_event_title_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_event_title_correctly.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264905,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264905,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
 - request:
@@ -104,7 +104,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264905,"msg_title":"Chef
@@ -116,7 +116,7 @@ http_interactions:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -138,8 +138,8 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "normal", "date_happened":
-        1410264905, "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
+      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264905,
+        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507757931012345",
         "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
@@ -154,10 +154,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -183,8 +183,47 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:19 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_event_title_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_event_title_correctly.yml
@@ -5,194 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:04 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264905,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:04 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264905,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:05 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
-        [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
-        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264905,"msg_title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"Chef updated
-        6 resources out of 6 resources total.\n$$$\n- [paws] (dynamically defined)\n-
-        [ears] (dynamically defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically
-        defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:05 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '729'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264905,
-        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507757931012345",
-        "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
-        (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
-        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n",
-        "tags": ["env:hostile", "role:highlander", "tag:the_one_and_only"], "related_event_id":
-        null, "id": 2449507757931012345}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:06 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '112'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
-        "role:highlander", "tag:the_one_and_only"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:05 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1453838669,1.0]],"type":"counter","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -210,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:19 GMT
+      - Tue, 26 Jan 2016 20:04:27 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -225,5 +38,221 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838669,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838669,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838669,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"\n$$$\n- [paws] (dynamically defined)\n- [ears] (dynamically
+        defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically defined)\n-
+        [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838669,"msg_title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n-
+        [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
+        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '647'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236719251068806,"title":"Chef failed
+        in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n- [paws]
+        (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
+        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838669,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236719251068806"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 9Q+iFAw9d2jVl1KLdG/nY8rs36fWfVouK6InLAr8+BM=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_priority_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_priority_correctly.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264908,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264908,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
 - request:
@@ -104,7 +104,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
+      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
         [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
         defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264908,"msg_title":"Chef
@@ -116,7 +116,7 @@ http_interactions:
         Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -138,8 +138,8 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "normal", "date_happened":
-        1410264908, "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
+      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264908,
+        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507804185796858",
         "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
         (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
@@ -154,10 +154,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -183,8 +183,47 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:19 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_priority_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/failed_Chef_run/sets_priority_correctly.yml
@@ -5,194 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:06 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264908,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:07 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264908,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:07 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 6 resources out of 6 resources total.\n$$$\n-
-        [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
-        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1410264908,"msg_title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"Chef updated
-        6 resources out of 6 resources total.\n$$$\n- [paws] (dynamically defined)\n-
-        [ears] (dynamically defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically
-        defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:08 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '729'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264908,
-        "handle": null, "title": "Chef failed in 2 seconds on chef.handler.datadog.test-failed
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507804185796858",
-        "text": "Chef updated 6 resources out of 6 resources total.\n$$$\n- [paws]
-        (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
-        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
-        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n",
-        "tags": ["env:hostile", "role:highlander", "tag:the_one_and_only"], "related_event_id":
-        null, "id": 2449507804185796858}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:09 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '112'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
-        "role:highlander", "tag:the_one_and_only"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:08 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1453838669,1.0]],"type":"counter","host":"chef.handler.datadog.test-failed","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -210,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:19 GMT
+      - Tue, 26 Jan 2016 20:04:27 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -225,5 +38,221 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838669,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838669,6.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838669,2.0]],"type":"gauge","host":"chef.handler.datadog.test-failed","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"\n$$$\n- [paws] (dynamically defined)\n- [ears] (dynamically
+        defined)\n- [nose] (dynamically defined)\n- [tail] (dynamically defined)\n-
+        [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838669,"msg_title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","priority":"normal","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-failed","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n-
+        [paws] (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
+        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","host":"chef.handler.datadog.test-failed","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '647'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236709941151618,"title":"Chef failed
+        in 2 seconds on chef.handler.datadog.test-failed ","text":"\n$$$\n- [paws]
+        (dynamically defined)\n- [ears] (dynamically defined)\n- [nose] (dynamically
+        defined)\n- [tail] (dynamically defined)\n- [fur] (dynamically defined)\n\n$$$\n\n$$$\nChef::Exceptions::UnsupportedAction:
+        Something awry.\n$$$\n\n$$$\nwhiskers.rb:2\npaws.rb:1\nfile.rb:2\nfile.rb:1\n$$$\n","date_happened":1453838669,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236709941151618"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-failed?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:27 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 9Q+iFAw9d2jVl1KLdG/nY8rs36fWfVouK6InLAr8+BM=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-failed", "tags": ["env:hostile",
+        "role:highlander", "tag:the_one_and_only"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:57 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:57 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264901,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:58 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264901,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test-hostname ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-hostname","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test-hostname ","text":"Chef
-        updated 0 resources out of 0 resources total.","host":"chef.handler.datadog.test-hostname","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:58 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '389'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264901,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-hostname
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507639349448987",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507639349448987}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-hostname?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:14:59 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '71'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-hostname", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809606,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838669,1.0]],"type":"counter","host":"chef.handler.datadog.test-hostname","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:22 GMT
+      - Tue, 26 Jan 2016 20:04:24 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838669,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838669,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838669,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838669,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-hostname ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-hostname","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-hostname ","text":"Chef
+        updated 0 resources out of 0 resources total.","host":"chef.handler.datadog.test-hostname","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '359'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236660345629768,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-hostname ","text":"Chef updated
+        0 resources out of 0 resources total.","date_happened":1453838669,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236660345629768"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-hostname?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - iqUR658eMoTIiWZD4IiijxvuH1187cP4WmZ1rEzFTak=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-hostname", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_node_name_when_no_config_specified.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264901,0.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264901,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264901,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264901,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264901,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-hostname ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-hostname","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-hostname ","text":"Chef
         updated 0 resources out of 0 resources total.","host":"chef.handler.datadog.test-hostname","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264901,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264901,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-hostname
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507639349448987",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-hostname?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-hostname", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test-hostname", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:01 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809606,5.0]],"type":"gauge","host":"chef.handler.datadog.test-hostname","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:22 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:26 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264904,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264904,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264904,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264904,"msg_title":"Chef
         completed in 5 seconds on my-imaginary-hostname.local ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"my-imaginary-hostname.local","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on my-imaginary-hostname.local ","text":"Chef updated
         0 resources out of 0 resources total.","host":"my-imaginary-hostname.local","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264904,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264904,
         "handle": null, "title": "Chef completed in 5 seconds on my-imaginary-hostname.local
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507680654905647",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/my-imaginary-hostname.local?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "my-imaginary-hostname.local", "tags": ["env:testing"]}'
+      string: '{"host": "my-imaginary-hostname.local", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809607,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:22 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:27 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/hostname/uses_the_specified_hostname_when_provided.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:59 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264904,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:00 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264904,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:00 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264904,"msg_title":"Chef
-        completed in 5 seconds on my-imaginary-hostname.local ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"my-imaginary-hostname.local","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on my-imaginary-hostname.local ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"my-imaginary-hostname.local","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:01 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264904,
-        "handle": null, "title": "Chef completed in 5 seconds on my-imaginary-hostname.local
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507680654905647",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507680654905647}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/my-imaginary-hostname.local?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:02 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '64'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "my-imaginary-hostname.local", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:04 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809607,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838668,1.0]],"type":"counter","host":"my-imaginary-hostname.local","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:22 GMT
+      - Tue, 26 Jan 2016 20:04:23 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:27 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838668,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:23 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838668,0.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838668,5.0]],"type":"gauge","host":"my-imaginary-hostname.local","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838668,"msg_title":"Chef
+        completed in 5 seconds on my-imaginary-hostname.local ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"my-imaginary-hostname.local","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on my-imaginary-hostname.local ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"my-imaginary-hostname.local","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '352'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236652309264256,"title":"Chef completed
+        in 5 seconds on my-imaginary-hostname.local ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838668,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236652309264256"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/my-imaginary-hostname.local?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - wwu/bgxccjlNazhLUNsdV85F8rKnw6/fYnlKNBhfzOg=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '64'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "my-imaginary-hostname.local", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:28 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/does_not_use_the_instance_id_when_config_specified_to_false.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/does_not_use_the_instance_id_when_config_specified_to_false.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264899,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264899,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264899,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264899,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-ec2 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-ec2","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-ec2 ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test-ec2","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264899,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264899,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-ec2
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507590042992872",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-ec2?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-ec2", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test-ec2", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:17 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/does_not_use_the_instance_id_when_config_specified_to_false.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/does_not_use_the_instance_id_when_config_specified_to_false.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:54 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264899,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:54 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264899,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:55 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264899,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test-ec2 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-ec2","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test-ec2 ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-ec2","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:55 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '384'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264899,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-ec2
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507590042992872",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507590042992872}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-ec2?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:14:56 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '66'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-ec2", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:59 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838669,1.0]],"type":"counter","host":"chef.handler.datadog.test-ec2","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:17 GMT
+      - Tue, 26 Jan 2016 20:04:24 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838669,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:24 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838669,0.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838669,5.0]],"type":"gauge","host":"chef.handler.datadog.test-ec2","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838669,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-ec2 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test-ec2","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-ec2 ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-ec2","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '354'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236668415818934,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-ec2 ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838669,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236668415818934"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-ec2?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - o+T6KJmtlm7/lHIbU4qEQWVkGtrRMvLvLMnhkr5jg08=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '66'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-ec2", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:29 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_config_is_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_config_is_specified.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:51 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:52 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264896,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:53 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264896,"msg_title":"Chef
-        completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
-        of 0 resources total.","host":"i-123456","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:53 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '363'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264896,
-        "handle": null, "title": "Chef completed in 5 seconds on i-123456 ", "url":
-        "https://app.datadoghq.com/event/jump_to?event_id=2449507553450058109", "text":
-        "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507553450058109}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:14:54 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '45'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "i-123456", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838670,1.0]],"type":"counter","host":"i-123456","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:18 GMT
+      - Tue, 26 Jan 2016 20:04:25 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838670,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838670,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838670,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838670,"msg_title":"Chef
+        completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
+        of 0 resources total.","host":"i-123456","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '333'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236677124917119,"title":"Chef completed
+        in 5 seconds on i-123456 ","text":"Chef updated 0 resources out of 0 resources
+        total.","date_happened":1453838670,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236677124917119"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:25 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - Qw6ay549f1REjHQtMvVJOj5Z1lY6iWSI3exDAg0o39Y=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "i-123456", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_config_is_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_config_is_specified.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264896,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264896,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264896,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264896,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264896,"msg_title":"Chef
         completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
         of 0 resources total.","host":"i-123456","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264896,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264896,
         "handle": null, "title": "Chef completed in 5 seconds on i-123456 ", "url":
         "https://app.datadoghq.com/event/jump_to?event_id=2449507553450058109", "text":
         "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "i-123456", "tags": ["env:testing"]}'
+      string: '{"host": "i-123456", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:56 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:18 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_no_config_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_no_config_specified.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:49 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:49 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:50 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264893,"msg_title":"Chef
-        completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
-        of 0 resources total.","host":"i-123456","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:50 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '363'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
-        "handle": null, "title": "Chef completed in 5 seconds on i-123456 ", "url":
-        "https://app.datadoghq.com/event/jump_to?event_id=2449507503705612444", "text":
-        "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507503705612444}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:14:51 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '45'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "i-123456", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838670,1.0]],"type":"counter","host":"i-123456","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:17 GMT
+      - Tue, 26 Jan 2016 20:04:25 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838670,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838670,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838670,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838670,"msg_title":"Chef
+        completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
+        of 0 resources total.","host":"i-123456","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '333'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236685916283962,"title":"Chef completed
+        in 5 seconds on i-123456 ","text":"Chef updated 0 resources out of 0 resources
+        total.","date_happened":1453838670,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236685916283962"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:26 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - Lqo3/ximEWPWj/q8nw5y77qbM+7c3xo1aoVdmrbBiyU=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "i-123456", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:30 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_no_config_specified.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_correct_hostname_on_an_ec2_node/uses_the_instance_id_when_no_config_specified.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,0.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264893,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264893,"msg_title":"Chef
         completed in 5 seconds on i-123456 ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"i-123456","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on i-123456 ","text":"Chef updated 0 resources out
         of 0 resources total.","host":"i-123456","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
         "handle": null, "title": "Chef completed in 5 seconds on i-123456 ", "url":
         "https://app.datadoghq.com/event/jump_to?event_id=2449507503705612444", "text":
         "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/i-123456?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "i-123456", "tags": ["env:testing"]}'
+      string: '{"host": "i-123456", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809602,5.0]],"type":"gauge","host":"i-123456","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:17 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/posts_an_event.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:20 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:21 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264925,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:21 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264925,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:22 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '380'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264925,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508030241755204",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449508030241755204}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:22 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '62'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809605,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838674,1.0]],"type":"counter","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:21 GMT
+      - Tue, 26 Jan 2016 20:04:29 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:25 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838674,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838674,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838674,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838674,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '350'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236744299842747,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838674,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236744299842747"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 1TZ9yjqyTQEuQgFvlhDrXBTp0x7coU279EZsIv2sDHg=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/posts_an_event.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264925,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264925,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264925,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264925,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264925,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264925,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264925,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508030241755204",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:25 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809605,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:21 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:25 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/sets_priority_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/sets_priority_correctly.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:23 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:23 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264927,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:23 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264927,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:24 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '380'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264927,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508070456799406",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449508070456799406}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:24 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '62'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809606,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838673,1.0]],"type":"counter","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:21 GMT
+      - Tue, 26 Jan 2016 20:04:28 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838673,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838673,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838673,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838673,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '350'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236735158043892,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838673,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236735158043892"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - Ea9uTuX7DSH7tTxx4/x8Cs66HtgW5sIpm2bNulg8W+0=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/sets_priority_correctly.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_events/sets_priority_correctly.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264927,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264927,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264927,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264927,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264927,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264927,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264927,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508070456799406",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:27 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809606,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:21 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:26 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_metrics/reports_metrics.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_metrics/reports_metrics.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264921,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264921,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264921,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264921,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264921,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264921,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507977947172931",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809605,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:20 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:25 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_metrics/reports_metrics.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/emits_metrics/reports_metrics.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:17 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264921,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:17 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264921,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:18 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264921,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:18 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '380'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264921,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507977947172931",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449507977947172931}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:19 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '62'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:21 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809605,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838674,1.0]],"type":"counter","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:20 GMT
+      - Tue, 26 Jan 2016 20:04:29 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:25 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838674,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:29 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838674,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838674,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838674,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '350'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236751983296521,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838674,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236751983296521"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 1TZ9yjqyTQEuQgFvlhDrXBTp0x7coU279EZsIv2sDHg=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:34 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/sets_tags/puts_the_tags_for_the_current_node.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/sets_tags/puts_the_tags_for_the_current_node.yml
@@ -5,183 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:25 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:25 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264929,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:26 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264929,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
-        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:26 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '380'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264929,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508104833315150",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
-        "related_event_id": null, "id": 2449508104833315150}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:testing"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:27 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '62'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809604,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838673,1.0]],"type":"counter","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -199,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:20 GMT
+      - Tue, 26 Jan 2016 20:04:28 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -214,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:24 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838673,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838673,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838673,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838673,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '350'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236727437637511,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838673,"handle":null,"priority":"low","related_event_id":null,"tags":["env:testing"],"url":"https://app.datadoghq.com/event/event?id=381236727437637511"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:testing"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:28 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - o+T6KJmtlm7/lHIbU4qEQWVkGtrRMvLvLMnhkr5jg08=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:33 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/sets_tags/puts_the_tags_for_the_current_node.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/reports_metrics_event_and_sets_tags/sets_tags/puts_the_tags_for_the_current_node.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264929,0.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264929,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264929,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
 - request:
@@ -104,13 +104,13 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264929,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1410264929,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","priority":"low","parent":null,"tags":["env:testing"],"aggregation_key":"chef.handler.datadog.test","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -132,7 +132,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264929,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264929,
         "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449508104833315150",
         "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:testing"],
@@ -144,10 +144,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:testing"]}'
+      string: '{"tags":["env:testing"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -173,7 +173,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
+      string: '{"host": "chef.handler.datadog.test", "tags": ["env:testing"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:29 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809604,5.0]],"type":"gauge","host":"chef.handler.datadog.test","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:20 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:24 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/only_emits_a_failure_metric.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/only_emits_a_failure_metric.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1452808903,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 14 Jan 2016 22:01:43 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: Invalid API Key
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:01:43 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
+        may have occurred.","date_happened":1452808903,"msg_title":"Chef failed during
+        compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 14 Jan 2016 22:01:44 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: Invalid API Key
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:01:44 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:resources"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Jan 2016 22:01:44 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '51'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors": ["Invalid API key"]}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:01:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/only_emits_a_failure_metric.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/only_emits_a_failure_metric.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.run.success","points":[[1452808903,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838672,1.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -17,13 +17,13 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 403
-      message: Forbidden
+      code: 202
+      message: Accepted
     headers:
       Content-Type:
-      - text/plain; charset=utf-8
+      - text/json
       Date:
-      - Thu, 14 Jan 2016 22:01:43 GMT
+      - Tue, 26 Jan 2016 20:04:32 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -31,21 +31,21 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: Invalid API Key
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:01:43 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
       string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
-        may have occurred.","date_happened":1452808903,"msg_title":"Chef failed during
+        may have occurred.","date_happened":1453838672,"msg_title":"Chef failed during
         compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
         was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
@@ -60,13 +60,13 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 403
-      message: Forbidden
+      code: 202
+      message: Accepted
     headers:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 14 Jan 2016 22:01:44 GMT
+      - Tue, 26 Jan 2016 20:04:32 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -74,14 +74,16 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Content-Length:
-      - '15'
+      - '401'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: Invalid API Key
+      string: '{"status":"ok","event":{"id":381236787786934568,"title":"Chef failed
+        during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","date_happened":1453838672,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:resources"],"url":"https://app.datadoghq.com/event/event?id=381236787786934568"}}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:01:44 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
@@ -99,34 +101,34 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 403
-      message: Forbidden
+      code: 201
+      message: Created
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2016 22:01:44 GMT
+      - Tue, 26 Jan 2016 20:04:32 GMT
       Dd-Pool:
       - dogweb_sameorig
       Pragma:
       - no-cache
       Strict-Transport-Security:
       - max-age=15724800;
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
+      X-Dd-Debug:
+      - 4iA0gEW3U+JPEQU/L1uUqRuaUwdDN4h3ejNHIRKagxs=
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '51'
+      - '74'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"errors": ["Invalid API key"]}'
+      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:01:44 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/posts_an_event.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef was unable to complete a run, an error during compilation
+      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
         may have occurred.","date_happened":1410264903,"msg_title":"Chef failed during
         compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
         was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -34,9 +34,9 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "normal", "date_happened":
-        1410264903, "handle": null, "title": "Chef failed during compile phase on
-        chef.handler.datadog.test-resources ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507720114974929",
+      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264903,
+        "handle": null, "title": "Chef failed during compile phase on chef.handler.datadog.test-resources
+        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507720114974929",
         "text": "Chef was unable to complete a run, an error during compilation may
         have occurred.", "tags": ["env:resources"], "related_event_id": null, "id":
         2449507720114974929}}'
@@ -47,10 +47,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:resources"]}'
+      string: '{"tags":["env:resources"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -76,7 +76,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
+      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:15:03 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1452809594,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:15 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:15 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase/posts_an_event.yml
@@ -2,89 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
-        may have occurred.","date_happened":1410264903,"msg_title":"Chef failed during
-        compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
-        was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:15:03 GMT
-      Server:
-      - dogdispatcher/5.2.0
-      Content-Length:
-      - '431'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "normal", "date_happened": 1410264903,
-        "handle": null, "title": "Chef failed during compile phase on chef.handler.datadog.test-resources
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507720114974929",
-        "text": "Chef was unable to complete a run, an error during compilation may
-        have occurred.", "tags": ["env:resources"], "related_event_id": null, "id":
-        2449507720114974929}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:03 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:resources"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:15:03 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '74'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:15:03 GMT
-- request:
-    method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.run.success","points":[[1452809594,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838671,1.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -102,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:15 GMT
+      - Tue, 26 Jan 2016 20:04:31 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -117,5 +38,97 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:15 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
+        may have occurred.","date_happened":1453838672,"msg_title":"Chef failed during
+        compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:32 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '401'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236783340100567,"title":"Chef failed
+        during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","date_happened":1453838672,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:resources"],"url":"https://app.datadoghq.com/event/event?id=381236783340100567"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:resources"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:32 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - Lqo3/ximEWPWj/q8nw5y77qbM+7c3xo1aoVdmrbBiyU=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '74'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:32 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
@@ -202,4 +202,43 @@ http_interactions:
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
   recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809600,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:16 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838676,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -21,28 +21,30 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:21 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1428248966,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838676,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -58,28 +60,30 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:22 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1428248966,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838676,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -95,28 +99,69 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:23 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838676,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1428248966,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838676,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
@@ -135,27 +180,26 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/plain; charset=utf-8
       Date:
-      - Sun, 05 Apr 2015 15:49:23 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '420'
+      - '396'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1428248966,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-tags
-        ", "url": "https://app.datadoghq.com/event/event?id=2751230185062799345",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:hostile",
-        "role:highlander", "tag:the_one_and_only"], "related_event_id": null, "id":
-        2751230185062799345}}'
+      string: '{"status":"ok","event":{"id":381236778694851193,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838676,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236778694851193"}}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
@@ -181,15 +225,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 05 Apr 2015 15:49:24 GMT
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - dogweb_sameorig
       Pragma:
       - no-cache
-      Server:
-      - gunicorn/19.1.0
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       X-Dd-Debug:
-      - mPU4gm+hKkKT8ia9ZdY5CzVKb87xvoCEvNtumo6b6Z8=
+      - EhhnoBinSJ/mFOFx8c30LkIq8VSKonD/kqf6I2QWUws=
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
@@ -201,44 +247,5 @@ http_interactions:
       string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
         "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:26 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809600,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json
-      Date:
-      - Thu, 14 Jan 2016 22:13:16 GMT
-      Dd-Pool:
-      - propjoe
-      Strict-Transport-Security:
-      - max-age=15724800;
-      X-Content-Type-Options:
-      - nosniff
-      Content-Length:
-      - '16'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"status": "ok"}'
-    http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:20 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_unspecified/sets_role_env_and_nothing_else.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_unspecified/sets_role_env_and_nothing_else.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1428248969,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838675,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -21,28 +21,30 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:25 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1428248969,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838675,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -58,28 +60,30 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:26 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1428248969,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838675,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -95,28 +99,69 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/json
       Date:
-      - Sun, 05 Apr 2015 15:49:26 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '15'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok"}'
+      string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838675,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
 - request:
     method: post
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1428248969,"msg_title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838675,"msg_title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
@@ -135,26 +180,26 @@ http_interactions:
       message: Accepted
     headers:
       Content-Type:
-      - text/json; charset=UTF-8
+      - text/plain; charset=utf-8
       Date:
-      - Sun, 05 Apr 2015 15:49:27 GMT
-      Server:
-      - dogdispatcher/6.1.23
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       Content-Length:
-      - '396'
+      - '373'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1428248969,
-        "handle": null, "title": "Chef completed in 5 seconds on chef.handler.datadog.test-tags
-        ", "url": "https://app.datadoghq.com/event/event?id=2751230245696245756",
-        "text": "Chef updated 0 resources out of 0 resources total.", "tags": ["env:hostile",
-        "role:highlander"], "related_event_id": null, "id": 2751230245696245756}}'
+      string: '{"status":"ok","event":{"id":381236770623842597,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1453838675,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander"],"url":"https://app.datadoghq.com/event/event?id=381236770623842597"}}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
@@ -180,15 +225,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 05 Apr 2015 15:49:28 GMT
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - dogweb_sameorig
       Pragma:
       - no-cache
-      Server:
-      - gunicorn/19.1.0
       Strict-Transport-Security:
       - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
       X-Dd-Debug:
-      - K5UeadTtPqoFikPi1o+Wft0+9g+d2LCw4qfYk8mXP20=
+      - uTibUUKQfObPuIZxjR4qd7DtXl7nOORJ69j/2Xrv/+E=
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
@@ -200,44 +247,5 @@ http_interactions:
       string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
         "role:highlander"]}'
     http_version: 
-  recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json
-      Date:
-      - Thu, 14 Jan 2016 22:13:16 GMT
-      Dd-Pool:
-      - propjoe
-      Strict-Transport-Security:
-      - max-age=15724800;
-      X-Content-Type-Options:
-      - nosniff
-      Content-Length:
-      - '16'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"status": "ok"}'
-    http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:35 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_unspecified/sets_role_env_and_nothing_else.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_unspecified/sets_role_env_and_nothing_else.yml
@@ -201,4 +201,43 @@ http_interactions:
         "role:highlander"]}'
     http_version: 
   recorded_at: Sun, 05 Apr 2015 15:49:29 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809601,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:16 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:21 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/updated_resources/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/updated_resources/posts_an_event.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.total","points":[[1410264893,2.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264893,2.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -38,10 +38,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -71,10 +71,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status":"ok"}'
+      string: '{"status":"ok"}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
 - request:
@@ -104,7 +104,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: ! '{"msg_text":"Chef updated 1 resources out of 2 resources total.\n$$$\n-
+      string: '{"msg_text":"Chef updated 1 resources out of 2 resources total.\n$$$\n-
         [whiskers] (dynamically defined)\n\n$$$\n","date_happened":1410264893,"msg_title":"Chef
         completed in 8 seconds on chef.handler.datadog.test-resources ","priority":"low","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 8 seconds on chef.handler.datadog.test-resources ","text":"Chef
@@ -112,7 +112,7 @@ http_interactions:
         defined)\n\n$$$\n","host":"chef.handler.datadog.test-resources","device":null}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -134,7 +134,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
+      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
         "handle": null, "title": "Chef completed in 8 seconds on chef.handler.datadog.test-resources
         ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507457417842743",
         "text": "Chef updated 1 resources out of 2 resources total.\n$$$\n- [whiskers]
@@ -147,10 +147,10 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: ! '{"tags":["env:resources"]}'
+      string: '{"tags":["env:resources"]}'
     headers:
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
       Content-Type:
@@ -176,7 +176,46 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
+      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
     http_version: 
   recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809604,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 14 Jan 2016 22:13:17 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 14 Jan 2016 22:13:24 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/updated_resources/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/updated_resources/posts_an_event.yml
@@ -5,186 +5,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.total","points":[[1410264893,2.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:46 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.updated","points":[[1410264893,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:46 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1410264893,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:47 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '15'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status":"ok"}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"msg_text":"Chef updated 1 resources out of 2 resources total.\n$$$\n-
-        [whiskers] (dynamically defined)\n\n$$$\n","date_happened":1410264893,"msg_title":"Chef
-        completed in 8 seconds on chef.handler.datadog.test-resources ","priority":"low","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
-        completed in 8 seconds on chef.handler.datadog.test-resources ","text":"Chef
-        updated 1 resources out of 2 resources total.\n$$$\n- [whiskers] (dynamically
-        defined)\n\n$$$\n","host":"chef.handler.datadog.test-resources","device":null}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Type:
-      - text/json; charset=UTF-8
-      Date:
-      - Tue, 09 Sep 2014 12:14:47 GMT
-      Server:
-      - dogdispatcher/5.1.1
-      Content-Length:
-      - '442'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"status": "ok", "event": {"priority": "low", "date_happened": 1410264893,
-        "handle": null, "title": "Chef completed in 8 seconds on chef.handler.datadog.test-resources
-        ", "url": "https://app.datadoghq.com/event/jump_to?event_id=2449507457417842743",
-        "text": "Chef updated 1 resources out of 2 resources total.\n$$$\n- [whiskers]
-        (dynamically defined)\n\n$$$\n", "tags": ["env:resources"], "related_event_id":
-        null, "id": 2449507457417842743}}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: put
-    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
-    body:
-      encoding: UTF-8
-      string: '{"tags":["env:resources"]}'
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Sep 2014 12:14:48 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - gunicorn/19.1.0
-      Content-Length:
-      - '74'
-      Connection:
-      - keep-alive
-    body:
-      encoding: US-ASCII
-      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
-    http_version: 
-  recorded_at: Tue, 09 Sep 2014 12:14:53 GMT
-- request:
-    method: post
-    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
-    body:
-      encoding: UTF-8
-      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1452809604,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838678,1.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -202,7 +23,7 @@ http_interactions:
       Content-Type:
       - text/json
       Date:
-      - Thu, 14 Jan 2016 22:13:17 GMT
+      - Tue, 26 Jan 2016 20:04:30 GMT
       Dd-Pool:
       - propjoe
       Strict-Transport-Security:
@@ -217,5 +38,213 @@ http_interactions:
       encoding: UTF-8
       string: '{"status": "ok"}'
     http_version: 
-  recorded_at: Thu, 14 Jan 2016 22:13:24 GMT
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838678,2.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838678,1.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838678,8.0]],"type":"gauge","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"\n$$$\n- [whiskers] (dynamically defined)\n\n$$$\n","date_happened":1453838678,"msg_title":"Chef
+        completed in 8 seconds on chef.handler.datadog.test-resources ","priority":"low","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 8 seconds on chef.handler.datadog.test-resources ","text":"\n$$$\n-
+        [whiskers] (dynamically defined)\n\n$$$\n","host":"chef.handler.datadog.test-resources","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '362'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":381236762571463232,"title":"Chef completed
+        in 8 seconds on chef.handler.datadog.test-resources ","text":"\n$$$\n- [whiskers]
+        (dynamically defined)\n\n$$$\n","date_happened":1453838678,"handle":null,"priority":"low","related_event_id":null,"tags":["env:resources"],"url":"https://app.datadoghq.com/event/event?id=381236762571463232"}}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:resources"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:30 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - QKcGho/VVHvOvAFq4WeaqBhqhL8eYL3K9CW+TToIP+o=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '74'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-resources", "tags": ["env:resources"]}'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 20:04:38 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
The DataDog event system does not allow for counting and processing number of events in timeseries graphs. This will add a success and failure metrics for generating running percentages of chef-client success.