### PR TITLE
Allow users to specify custom tag prefix with config[:tag_prefix]

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -55,7 +55,8 @@ class Chef
             .with_hostname(hostname)
             .with_run_status(run_status)
             .with_application_key(config[:application_key])
-            .with_retries(@config[:tags_submission_retries])
+            .with_tag_prefix(config[:tag_prefix])
+            .with_retries(config[:tags_submission_retries])
 
         # Build the chef event information
         @event =

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -10,7 +10,7 @@ class DatadogChefTags
     @node = nil
     @run_status = nil
     @application_key = nil
-    @tag_prefix = 'tag'
+    @tag_prefix = 'tag:'
     @retries = 0
     @combined_host_tags = nil
   end
@@ -135,6 +135,6 @@ class DatadogChefTags
 
   def node_tags
     return [] unless @node.tags
-    @tag_prefix.empty? ? @node.tags : @node.tags.map { |tag| "#{@tag_prefix}:#{tag}" }
+    @node.tags.map { |tag| "#{@tag_prefix}#{tag}" }
   end
 end # end class DatadogChefTags

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -10,6 +10,7 @@ class DatadogChefTags
     @node = nil
     @run_status = nil
     @application_key = nil
+    @tag_prefix = 'tag'
     @retries = 0
     @combined_host_tags = nil
   end
@@ -23,11 +24,6 @@ class DatadogChefTags
     self
   end
 
-  # attribute accessor for combined array of tags
-  #
-  # @return [Array] the set of host tags based off the chef run
-  attr_reader :combined_host_tags
-
   # set the chef run status used for the report
   #
   # @param run_status [Chef::RunStatus] current chef run status
@@ -38,13 +34,6 @@ class DatadogChefTags
     # Selects all [env, roles, tags] from the Node's object and reformats
     # them to `key:value` e.g. `role:database-master`.
     @node = run_status.node
-    # generate the combined tags
-    chef_env = node_env.split # converts a string into an array
-    chef_roles = node_roles
-    chef_tags = node_tags
-
-    # Combine (union) all arrays. Removes duplicates if found.
-    @combined_host_tags = chef_env | chef_roles | chef_tags
     self
   end
 
@@ -77,6 +66,15 @@ class DatadogChefTags
     self
   end
 
+  # set the prefix to be added to all Chef tags
+  #
+  # @param tag_prefix [String] prefix to be added to all Chef tags
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_tag_prefix(tag_prefix)
+    @tag_prefix = tag_prefix unless tag_prefix.nil?
+    self
+  end
+
   # set the number of retries when sending tags, when the host is not yet present
   # on Datadog
   #
@@ -89,11 +87,12 @@ class DatadogChefTags
 
   # send updated chef run generated tags to Datadog
   def send_update_to_datadog
+    tags = combined_host_tags
     retries = @retries
     begin
       loop do
         should_retry = false
-        rc = @dog.update_tags(@hostname, combined_host_tags, 'chef')
+        rc = @dog.update_tags(@hostname, tags, 'chef')
         # See FIXME in DatadogChefEvents::emit_to_datadog about why I feel dirty repeating this code here
         if rc.length < 2
           Chef::Log.warn("Unexpected response from Datadog Tags API: #{rc}")
@@ -104,9 +103,9 @@ class DatadogChefTags
             retries -= 1
             should_retry = true
           elsif rc[0].to_i / 100 != 2
-            Chef::Log.warn("Could not submit #{combined_host_tags} tags for #{@hostname} to Datadog: #{rc}")
+            Chef::Log.warn("Could not submit #{tags} tags for #{@hostname} to Datadog: #{rc}")
           else
-            Chef::Log.debug("Successfully updated #{@hostname}'s tags to #{combined_host_tags.join(', ')}")
+            Chef::Log.debug("Successfully updated #{@hostname}'s tags to #{tags.join(', ')}")
           end
         end
         break unless should_retry
@@ -114,6 +113,14 @@ class DatadogChefTags
     rescue
       Chef::Log.warn("Could not determine whether #{@hostname}'s tags were successfully submitted to Datadog: #{rc}")
     end
+  end
+
+  # return a combined array of tags that should be sent to Datadog
+  #
+  # @return [Array] the set of host tags based off the chef run
+  def combined_host_tags
+    # Combine (union) all arrays. Removes duplicates if found.
+    node_env.split | node_roles | node_tags
   end
 
   private
@@ -127,6 +134,7 @@ class DatadogChefTags
   end
 
   def node_tags
-    @node.tags ? @node.tags.map! { |tag| 'tag:' + tag } : []
+    return [] unless @node.tags
+    @tag_prefix.empty? ? @node.tags : @node.tags.map { |tag| "#{@tag_prefix}:#{tag}" }
   end
 end # end class DatadogChefTags

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -219,7 +219,7 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
 
       it 'allows for user-specified tag prefix' do
         @node.normal.tags = ['the_one_and_only', 'datacenter:my-cloud']
-        @handler.config[:tag_prefix] = 'custom-prefix'
+        @handler.config[:tag_prefix] = 'custom-prefix-'
         @handler.run_report_unsafe(@run_status)
 
         expect(a_request(:put, HOST_TAG_ENDPOINT + @node.name).with(
@@ -227,7 +227,7 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
                       'application_key' => @handler.config[:application_key],
                       'source' => 'chef' },
           :body => hash_including(:tags => [
-            'env:hostile', 'role:highlander', 'custom-prefix:the_one_and_only', 'custom-prefix:datacenter:my-cloud'
+            'env:hostile', 'role:highlander', 'custom-prefix-the_one_and_only', 'custom-prefix-datacenter:my-cloud'
             ]),
          )).to have_been_made.times(1)
       end

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/allows_for_empty_tag_prefix.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/allows_for_empty_tag_prefix.yml
@@ -1,0 +1,251 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1458250870,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1458250870,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1458250870,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1458250870,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1458250870,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":null,"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '344'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":455261105802551673,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1458250870,"handle":null,"priority":"low","related_event_id":null,"tags":null,"url":"https://app.datadoghq.com/event/event?id=455261105802551673"}}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:05 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - Bj/SqNU1vbZGxNGffIRtmaWe7MKGSPoKHC3+ZhLAjqk=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '86'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
+        "role:highlander"]}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:10 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/allows_for_user-specified_tag_prefix.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/allows_for_user-specified_tag_prefix.yml
@@ -1,0 +1,251 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1458250868,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1458250868,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1458250868,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1458250868,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1458250868,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":null,"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '344'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":455261092784026415,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1458250868,"handle":null,"priority":"low","related_event_id":null,"tags":null,"url":"https://app.datadoghq.com/event/event?id=455261092784026415"}}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Mar 2016 21:41:04 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - QYSb9ZUj91gVP/VyhgpNnm/M7M7fif9QER6YVwRajIA=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '86'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
+        "role:highlander"]}'
+    http_version: 
+  recorded_at: Thu, 17 Mar 2016 21:41:08 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_specified/sets_the_role_and_env_and_tags.yml
@@ -161,8 +161,8 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
     body:
       encoding: UTF-8
-      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1453838676,"msg_title":"Chef
-        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1458601273,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only","tag:datacenter:my-cloud"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
         completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
         0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
     headers:
@@ -190,22 +190,22 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Content-Length:
-      - '396'
+      - '422'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"status":"ok","event":{"id":381236778694851193,"title":"Chef completed
+      string: '{"status":"ok","event":{"id":461139917332183580,"title":"Chef completed
         in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
-        out of 0 resources total.","date_happened":1453838676,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only"],"url":"https://app.datadoghq.com/event/event?id=381236778694851193"}}'
+        out of 0 resources total.","date_happened":1458601273,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only","tag:datacenter:my-cloud"],"url":"https://app.datadoghq.com/event/event?id=461139917332183580"}}'
     http_version: 
-  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+  recorded_at: Mon, 21 Mar 2016 23:01:13 GMT
 - request:
     method: put
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only"]}'
+      string: '{"tags":["env:hostile","role:highlander","tag:the_one_and_only","tag:datacenter:my-cloud"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -239,13 +239,13 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '110'
+      - '137'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"host": "chef.handler.datadog.test-tags", "tags": ["env:hostile",
-        "role:highlander", "tag:the_one_and_only"]}'
+      string: '{"host": "chef.handler.datadog.test-tags", "tags": ["tag:datacenter:my-cloud",
+        "env:hostile", "role:highlander", "tag:the_one_and_only"]}'
     http_version: 
   recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This is an alternative solution for https://github.com/DataDog/chef-handler-datadog/issues/58

User can decide to send tags unprefixed by passing an optional `tag_prefix = ''` config value to chef-handler-datadog. Default prefix is still `'tag:'`. Backwards compatibility is preserved.