### PR TITLE
always emit success and failure so monitors recover

### DIFF
--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -39,7 +39,8 @@ class DatadogChefMetrics
   # Emit Chef metrics to Datadog
   def emit_to_datadog
     # Send base success/failure metric
-    @dog.emit_point(@run_status.success? ? 'chef.run.success' : 'chef.run.failure', 1, host: @hostname, type: 'counter')
+    @dog.emit_point('chef.run.success', @run_status.success? ? 1 : 0, host: @hostname, type: 'counter')
+    @dog.emit_point('chef.run.failure', @run_status.success? ? 0 : 1, host: @hostname, type: 'counter')
 
     # If there is a failure during compile phase, a large portion of
     # run_status may be unavailable. Bail out here


### PR DESCRIPTION
as it is, when monitoring chef.run.failure, monitors never recover and just go from alert -> no data and require manual intervention to recover

sending a zero failure counter on success means that these monitors will recover when chef runs succeed