### PR TITLE
Fix test setup (gem deps install)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ rvm:
   - 1.9.3
   - 2.1.5
 
+before_install:
+  - gem update --system
+  - gem --version
+  - gem install bundler --pre
+
 bundler_args: --without=localdev
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ rvm:
 before_install:
   - gem update --system
   - gem --version
-  - gem install bundler --pre
+  # Use a stable version once 1.13.0 is released
+  - gem install bundler --version 1.13.0.rc.1
 
 bundler_args: --without=localdev
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # Latest release of mainline Chef versions here.
-%w(10 11 12).each do |tv|
+%w(10 12).each do |tv|
   appraise "chef-#{tv}" do
     gem 'chef', "~> #{tv}.0"
   end
@@ -13,4 +13,12 @@ appraise 'chef-10.14.4' do
   # Old versions of Chef didn't pin the max version of Ohai they supported.
   # See: http://git.io/vecAn
   gem 'ohai', '< 8.0'
+end
+
+appraise 'chef-11' do
+  gem 'chef', '~> 11.0'
+  # for some reason bundler installs json 2.x and rack 2.x even when they don't support the version of
+  # ruby installed, so let's force compatible versions here
+  gem 'json', '< 2.0'
+  gem 'rack', '< 2.0'
 end

--- a/gemfiles/chef_11.gemfile
+++ b/gemfiles/chef_11.gemfile
@@ -3,6 +3,8 @@
 source "http://rubygems.org"
 
 gem "chef", "~> 11.0"
+gem "json", "< 2.0"
+gem "rack", "< 2.0"
 
 group :localdev do
   gem "guard"


### PR DESCRIPTION
1. Update rubygems and bundler in `before_install` step: This makes rubygems and bundler slightly smarter in terms of installing gems that are compatible with the version of ruby
2. Force `json` and `rack` version constraints for chef 11 (unfortunately `1.` is not enough for the `chef-11` tests apparently...)