### PR TITLE
Send policy name and policy group as chef tags

### DIFF
--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -113,7 +113,7 @@ class DatadogChefTags
   # @return [Array] the set of host tags based off the chef run
   def combined_host_tags
     # Combine (union) all arrays. Removes duplicates if found.
-    node_env.split | node_roles | Array(node_policy_group) | Array(node_policy_name) | node_tags
+    node_env.split | node_roles | node_policy_tags | node_tags
   end
 
   private
@@ -126,12 +126,17 @@ class DatadogChefTags
     "#{@scope_prefix}env:#{@node.chef_environment}" if @node.respond_to?('chef_environment')
   end
 
-  def node_policy_group
-    "#{@scope_prefix}policy-group:#{@node.policy_group}" unless @node.policy_group.nil?
-  end
-
-  def node_policy_name
-    "#{@scope_prefix}policy-name:#{@node.policy_name}" unless @node.policy_name.nil?
+  # Send the policy name and policy group as chef tags when using chef policyfiles feature
+  # The policy_group and policy_name attributes exist only for chef >= 12.5.1
+  def node_policy_tags
+    policy_tags = []
+    if @node.respond_to?('policy_group') && !@node.policy_group.nil?
+      policy_tags << "#{@scope_prefix}policy-group:#{@node.policy_group}"
+    end
+    if @node.respond_to?('policy_name') && !@node.policy_name.nil?
+      policy_tags << "#{@scope_prefix}policy-name:#{@node.policy_name}"
+    end
+    policy_tags
   end
 
   def node_tags

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -113,7 +113,7 @@ class DatadogChefTags
   # @return [Array] the set of host tags based off the chef run
   def combined_host_tags
     # Combine (union) all arrays. Removes duplicates if found.
-    node_env.split | node_roles | node_tags
+    node_env.split | node_roles | Array(node_policy_group) | Array(node_policy_name) | node_tags
   end
 
   private
@@ -124,6 +124,14 @@ class DatadogChefTags
 
   def node_env
     "#{@scope_prefix}env:#{@node.chef_environment}" if @node.respond_to?('chef_environment')
+  end
+
+  def node_policy_group
+    "#{@scope_prefix}policy-group:#{@node.policy_group}" unless @node.policy_group.nil?
+  end
+
+  def node_policy_name
+    "#{@scope_prefix}policy-name:#{@node.policy_name}" unless @node.policy_name.nil?
   end
 
   def node_tags

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -326,6 +326,10 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
     end
 
     describe 'when policy is specified' do
+      # This feature is available only for chef >= 12.5.1
+      if Chef::Version.new(Chef::VERSION) < Chef::Version.new("12.5.1")
+        next
+      end
       it 'sets the policy name and policy group tags' do
         @node.send(:policy_name, 'the_policy_name')
         @node.send(:policy_group, 'the_policy_group')

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -324,6 +324,23 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
         )).to have_been_made.times(1)
       end
     end
+
+    describe 'when policy is specified' do
+      it 'sets the policy name and policy group tags' do
+        @node.send(:policy_name, 'the_policy_name')
+        @node.send(:policy_group, 'the_policy_group')
+        @handler.run_report_unsafe(@run_status)
+
+        expect(a_request(:put, HOST_TAG_ENDPOINT + @node.name).with(
+          :query => { 'api_key' => @handler.config[:api_key],
+                      'application_key' => @handler.config[:application_key],
+                      'source' => 'chef' },
+          :body => hash_including(:tags => [
+              'env:hostile', 'role:highlander', 'policy-group:the_policy_group', 'policy-name:the_policy_name'
+            ]),
+        )).to have_been_made.times(1)
+      end
+    end
   end
 
   context 'tags submission retries' do

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_is_specified/sets_the_policy_name_and_policy_group_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_is_specified/sets_the_policy_name_and_policy_group_tags.yml
@@ -1,0 +1,289 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1453838676,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1453838676,0.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1453838676,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1453838676,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1453838676,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1458601273,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only","tag:datacenter:my-cloud"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '422'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":461139917332183580,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1458601273,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander","tag:the_one_and_only","tag:datacenter:my-cloud"],"url":"https://app.datadoghq.com/event/event?id=461139917332183580"}}'
+    http_version:
+  recorded_at: Mon, 21 Mar 2016 23:01:13 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander","policy-group:the_policy_group","policy-name:the_policy_name"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Jan 2016 20:04:31 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - EhhnoBinSJ/mFOFx8c30LkIq8VSKonD/kqf6I2QWUws=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '137'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host": "chef.handler.datadog.test-tags", "tags":["env:hostile","role:highlander","policy-group:the_policy_group","policy-name:the_policy_name"]}'
+    http_version:
+  recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
It sends the policy name and policy group of the node as chef tags when using the chef policyfiles feature.
