### PR TITLE
Silence message that produces cron mail spam

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -96,7 +96,6 @@ class Chef
                               (config.key?(:use_ec2_instance_id) && config[:use_ec2_instance_id])
 
         if config[:hostname]
-          puts "found hostname #{config[:hostname]} in config object"
           config[:hostname]
         elsif use_ec2_instance_id && node.attribute?('ec2') && node.ec2.attribute?('instance_id')
           node.ec2.instance_id


### PR DESCRIPTION
This message somehow escapes the confines of chef-client's `--logfile` parameter and makes its way into my root mailbox every time Chef runs in cron. It looks like a debug statement that was accidentally left in.