### PR TITLE
Improve detection of compile time error before sending event

### DIFF
--- a/lib/chef/handler/datadog_chef_events.rb
+++ b/lib/chef/handler/datadog_chef_events.rb
@@ -4,8 +4,12 @@ require 'chef/handler'
 require 'chef/mash'
 require 'dogapi'
 
+require_relative 'datadog_util'
+
 # helper class for sending events about chef runs
 class DatadogChefEvents
+  include DatadogUtil
+
   def initialize
     @hostname = nil
     @run_status = nil
@@ -128,7 +132,7 @@ class DatadogChefEvents
   def build_event_data
     # bail early in case of a compiletime failure
     # OPTIMIZE: Use better inspectors to handle failure scenarios, refactor needed.
-    if @run_status.elapsed_time.nil?
+    if compile_error?
       @alert_type = 'error'
       @event_title = "Chef failed during compile phase on #{@hostname} "
       @event_priority = 'normal'

--- a/lib/chef/handler/datadog_chef_metrics.rb
+++ b/lib/chef/handler/datadog_chef_metrics.rb
@@ -1,8 +1,12 @@
 # encoding: utf-8
 require 'dogapi'
 
+require_relative 'datadog_util'
+
 # helper class for sending datadog metrics from a chef run
 class DatadogChefMetrics
+  include DatadogUtil
+
   def initialize
     @hostname = ''
     @run_status = nil
@@ -45,11 +49,5 @@ class DatadogChefMetrics
     Chef::Log.debug('Submitted Chef metrics back to Datadog')
   rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
     Chef::Log.error("Could not send metrics to Datadog. Connection error:\n" + e)
-  end
-
-  private
-
-  def compile_error?
-    @run_status.all_resources.nil? || @run_status.elapsed_time.nil? || @run_status.updated_resources.nil?
   end
 end # end class DatadogChefMetrics

--- a/lib/chef/handler/datadog_util.rb
+++ b/lib/chef/handler/datadog_util.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+# util class that groups common methods used by the helper classes
+module DatadogUtil
+  private
+
+  def compile_error?
+    @run_status.all_resources.nil? || @run_status.elapsed_time.nil? || @run_status.updated_resources.nil?
+  end
+end

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -546,12 +546,41 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
       @node = Chef::Node.build('chef.handler.datadog.test-resources')
       @node.send(:chef_environment, 'resources')
       @events = Chef::EventDispatch::Dispatcher.new
-      @run_context = Chef::RunContext.new(@node, {}, @events)
       @run_status = Chef::RunStatus.new(@node, @events)
     end
 
     context 'failure during compile phase' do
       before(:each) do
+        @handler.run_report_unsafe(@run_status)
+      end
+
+      it 'only emits the run status metrics' do
+        expect(a_request(:post, METRICS_ENDPOINT).with(
+          :query => { 'api_key' => @handler.config[:api_key] }
+        )).to have_been_made.times(2)
+      end
+
+      it 'posts an event' do
+        expect(a_request(:post, EVENTS_ENDPOINT).with(
+          :query => { 'api_key' => @handler.config[:api_key] },
+          :body => hash_including(:msg_text => 'Chef was unable to complete a run, an error during compilation may have occured.'),
+          :body => hash_including(:msg_title => "Chef failed during compile phase on #{@node.name} "),
+        )).to have_been_made.times(1)
+      end
+    end
+
+    context 'failure during compile phase with an elapsed time and incomplete resource collection' do
+      before(:each) do
+        @run_context = Chef::RunContext.new(@node, {}, @events)
+
+        allow(@run_context.resource_collection).to receive(:all_resources).and_return(nil)
+        @run_status.run_context = @run_context
+
+        @expected_time = Time.now
+        allow(Time).to receive(:now).and_return(@expected_time, @expected_time + 5)
+        @run_status.start_clock
+        @run_status.stop_clock
+
         @handler.run_report_unsafe(@run_status)
       end
 

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase_with_an_elapsed_time_and_incomplete_resource_collection/only_emits_the_run_status_metrics.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase_with_an_elapsed_time_and_incomplete_resource_collection/only_emits_the_run_status_metrics.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1485547327,1.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1485547327,0.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
+        may have occurred.","date_happened":1485547327,"msg_title":"Chef failed during
+        compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '401'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":913219659465841444,"title":"Chef failed
+        during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","date_happened":1485547327,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:resources"],"url":"https://app.datadoghq.com/event/event?id=913219659465841444"}}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:resources"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - tfYTpqMVXM3M7Ic3NSslg9OvOysbx8Mrdhv4OAsMKCDdYga06HUB/8z0VnhYMv3C
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host":"chef.handler.datadog.test-resources","tags":["env:resources"]}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase_with_an_elapsed_time_and_incomplete_resource_collection/posts_an_event.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/resources/failure_during_compile_phase_with_an_elapsed_time_and_incomplete_resource_collection/posts_an_event.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1485547327,1.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1485547327,0.0]],"type":"counter","host":"chef.handler.datadog.test-resources","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef was unable to complete a run, an error during compilation
+        may have occurred.","date_happened":1485547327,"msg_title":"Chef failed during
+        compile phase on chef.handler.datadog.test-resources ","priority":"normal","parent":null,"tags":["env:resources"],"aggregation_key":"chef.handler.datadog.test-resources","alert_type":"error","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        failed during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","host":"chef.handler.datadog.test-resources","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '401'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":913219665218676295,"title":"Chef failed
+        during compile phase on chef.handler.datadog.test-resources ","text":"Chef
+        was unable to complete a run, an error during compilation may have occurred.","date_happened":1485547327,"handle":null,"priority":"normal","related_event_id":null,"tags":["env:resources"],"url":"https://app.datadoghq.com/event/event?id=913219665218676295"}}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-resources?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:resources"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 27 Jan 2017 20:02:02 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - gViavZoY8rjtSLcIomJIWXS+mOF/f74cR9lPqFPI7NQ=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host":"chef.handler.datadog.test-resources","tags":["env:resources"]}'
+    http_version:
+  recorded_at: Fri, 27 Jan 2017 20:02:07 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
* use a util module to regroup the detection logic
* add a test that tries to reproduce what's been observed in the wild (most notably what's described in #92)

Supersedes #94, fixes #83 and #92

Also tested this manually on a chef-client compile error: could reproduce the issue, and this fixes it