### PR TITLE
[policy_tags] Enable with a flag (disabled by default)

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -59,6 +59,7 @@ class Chef
             .with_retries(config[:tags_submission_retries])
             .with_tag_blacklist(config[:tags_blacklist_regex])
             .with_scope_prefix(config[:scope_prefix])
+            .with_policy_tags_enabled(config[:send_policy_tags])
 
         # Build the chef event information
         @event =

--- a/lib/chef/handler/datadog_chef_tags.rb
+++ b/lib/chef/handler/datadog_chef_tags.rb
@@ -15,6 +15,7 @@ class DatadogChefTags
     @retries = 0
     @combined_host_tags = nil
     @regex_black_list = nil
+    @policy_tags_enabled = false
   end
 
   # set the chef run status used for the report
@@ -76,6 +77,15 @@ class DatadogChefTags
     self
   end
 
+  # enable policy tags
+  #
+  # @param enabled [TrueClass,FalseClass] enable or disable policy tags
+  # @return [DatadogChefTags] instance reference to self enabling method chaining
+  def with_policy_tags_enabled(enabled)
+    @policy_tags_enabled = enabled unless enabled.nil?
+    self
+  end
+
   # send updated chef run generated tags to Datadog
   #
   # @param dog [Dogapi::Client] Dogapi Client to be used
@@ -130,11 +140,13 @@ class DatadogChefTags
   # The policy_group and policy_name attributes exist only for chef >= 12.5.1
   def node_policy_tags
     policy_tags = []
-    if @node.respond_to?('policy_group') && !@node.policy_group.nil?
-      policy_tags << "#{@scope_prefix}policy-group:#{@node.policy_group}"
-    end
-    if @node.respond_to?('policy_name') && !@node.policy_name.nil?
-      policy_tags << "#{@scope_prefix}policy-name:#{@node.policy_name}"
+    if @policy_tags_enabled
+      if @node.respond_to?('policy_group') && !@node.policy_group.nil?
+        policy_tags << "#{@scope_prefix}policy_group:#{@node.policy_group}"
+      end
+      if @node.respond_to?('policy_name') && !@node.policy_name.nil?
+        policy_tags << "#{@scope_prefix}policy_name:#{@node.policy_name}"
+      end
     end
     policy_tags
   end

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_tags_are_enabled/sets_the_policy_name_and_policy_group_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_tags_are_enabled/sets_the_policy_name_and_policy_group_tags.yml
@@ -244,7 +244,7 @@ http_interactions:
     uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
     body:
       encoding: UTF-8
-      string: '{"tags":["env:hostile","role:highlander","policy-group:the_policy_group","policy-name:the_policy_name"]}'
+      string: '{"tags":["env:hostile","role:highlander","policy_group:the_policy_group","policy_name:the_policy_name"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -283,7 +283,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"host": "chef.handler.datadog.test-tags", "tags":["env:hostile","role:highlander","policy-group:the_policy_group","policy-name:the_policy_name"]}'
+      string: '{"host": "chef.handler.datadog.test-tags", "tags":["env:hostile","role:highlander","policy_group:the_policy_group","policy_name:the_policy_name"]}'
     http_version:
   recorded_at: Tue, 26 Jan 2016 20:04:36 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_tags_are_not_enabled/does_not_set_the_policy_name_and_policy_group_tags.yml
+++ b/spec/support/cassettes/Chef_Handler_Datadog/tags/when_policy_tags_are_not_enabled/does_not_set_the_policy_name_and_policy_group_tags.yml
@@ -1,0 +1,289 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.success","points":[[1486079857,1.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:32 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.run.failure","points":[[1486079857,0.0]],"type":"counter","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:32 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.total","points":[[1486079857,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:32 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.updated","points":[[1486079857,0.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:32 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/series?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"series":[{"metric":"chef.resources.elapsed_time","points":[[1486079857,5.0]],"type":"gauge","host":"chef.handler.datadog.test-tags","device":null}]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:33 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status": "ok"}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: post
+    uri: https://app.datadoghq.com/api/v1/events?api_key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"msg_text":"Chef updated 0 resources out of 0 resources total.","date_happened":1486079857,"msg_title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","priority":"low","parent":null,"tags":["env:hostile","role:highlander"],"aggregation_key":"chef.handler.datadog.test-tags","alert_type":"success","event_type":"config_management.run","source_type_name":"chef","title":"Chef
+        completed in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated
+        0 resources out of 0 resources total.","host":"chef.handler.datadog.test-tags","device":null}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 02 Feb 2017 23:57:33 GMT
+      Dd-Pool:
+      - propjoe
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '373'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","event":{"id":922154041878767484,"title":"Chef completed
+        in 5 seconds on chef.handler.datadog.test-tags ","text":"Chef updated 0 resources
+        out of 0 resources total.","date_happened":1486079857,"handle":null,"priority":"low","related_event_id":null,"tags":["env:hostile","role:highlander"],"url":"https://app.datadoghq.com/event/event?id=922154041878767484"}}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+- request:
+    method: put
+    uri: https://app.datadoghq.com/api/v1/tags/hosts/chef.handler.datadog.test-tags?api_key=<API_KEY>&application_key=<APPLICATION_KEY>&source=chef
+    body:
+      encoding: UTF-8
+      string: '{"tags":["env:hostile","role:highlander"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Feb 2017 23:57:33 GMT
+      Dd-Pool:
+      - dogweb_sameorig
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - fTGHC5140Slzi8+VUckQeb7JtG5SB73QXNv+4EfnG/s=
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '82'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"host":"chef.handler.datadog.test-tags","tags":["env:hostile","role:highlander"]}'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 23:57:37 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
To avoid too much context churn if the tags are sent by default.

Also replaced minuses with underscores in the tag keys.

Updated the existing test, and added a test to show that the default is indeed to not send the policy tags.