### PR TITLE
Using api_url for sending chef related data to extra_endpoints

### DIFF
--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -159,10 +159,7 @@ class Chef
         # then add extra endpoints
         extra_endpoints = @config[:extra_endpoints] || []
         extra_endpoints.each do |endpoint|
-          url = endpoint[:url] || config_url()
-          if endpoint[:api_url]
-            url = endpoint[:api_url]
-          end
+          url = endpoint[:api_url] || endpoint[:url] || config_url()
           api_key = endpoint[:api_key]
           app_key = endpoint[:application_key]
           endpoints << [url, api_key, app_key] if validate_keys(api_key, app_key, false)

--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -159,7 +159,7 @@ class Chef
         # then add extra endpoints
         extra_endpoints = @config[:extra_endpoints] || []
         extra_endpoints.each do |endpoint|
-          url = endpoint[:url] || config_url()
+          url = endpoint[:api_url] || config_url()
           api_key = endpoint[:api_key]
           app_key = endpoint[:application_key]
           endpoints << [url, api_key, app_key] if validate_keys(api_key, app_key, false)

--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -159,7 +159,10 @@ class Chef
         # then add extra endpoints
         extra_endpoints = @config[:extra_endpoints] || []
         extra_endpoints.each do |endpoint|
-          url = endpoint[:api_url] || config_url()
+          url = endpoint[:url] || config_url()
+          if endpoint[:api_url]
+            url = endpoint[:api_url]
+          end
           api_key = endpoint[:api_key]
           app_key = endpoint[:application_key]
           endpoints << [url, api_key, app_key] if validate_keys(api_key, app_key, false)

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -734,6 +734,31 @@ describe Chef::Handler::Datadog, :vcr => :new_episodes do
         expect(handler.send(:endpoints)).to eq(triplets[0..1])
       end
     end
+
+    context 'when using api url instead of url' do
+      it 'returns available triplets' do
+        triplets = [
+          ['https://app.datadoghq.com', 'api_key_2' , 'app_key_2'],
+          ['https://app.example.com', 'api_key_3', 'app_key_3'],
+          ['https://app.example.com', 'api_key_4', 'app_key_4']
+        ]
+        handler = Chef::Handler::Datadog.new api_key: triplets[0][1],
+                                             application_key: triplets[0][2],
+                                             url: triplets[0][0],
+                                             extra_endpoints: [{
+                                               api_url: triplets[1][0],
+                                               url: triplets[0][0],
+                                               api_key: triplets[1][1],
+                                               application_key: triplets[1][2]
+                                             }, {
+                                               api_url: triplets[2][0],
+                                               url:triplets[0][0],
+                                               api_key: triplets[2][1],
+                                               application_key: triplets[2][2]
+                                             }]
+        expect(handler.send(:endpoints)).to eq(triplets)
+      end
+    end
   end
 
   context 'when reporting to multiple endpoints' do


### PR DESCRIPTION
*Problem*

Currently the url's that are present in the configs of extra_endpoints are agent urls. When some pieces of chef data (e.g. data sent to route `...tags/hosts/`) are sent to these agent endpoints, they fail because the bunk-agent is unaware of these specific routes. 

*Prep-work*

Currently extra_endpoints are fitted with an attribute known as `api_url` (https://github.com/DataDog/devops/blob/ce78f86d231d1bfd2f0deedf0b9c647a52e9e0f9/environments/staging.rb#L71)

And they are added to the config here (https://github.com/DataDog/devops/blob/ce78f86d231d1bfd2f0deedf0b9c647a52e9e0f9/site-cookbooks/dd-base/recipes/extra_endpoints.rb#L25-L35). Notice if the api_url is not present, it will default to the default url.

*Solution*

Now that we know extra_endpoints will have an api_url that can handle these specific routes, we can set them as the url used by the chef handler to send data for extra_endpoints.
