### PR TITLE
Pin dogapi to 1.36.0

### DIFF
--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
-  gem.add_dependency 'dogapi', '>= 1.31'
+  gem.add_dependency 'dogapi', '= 1.36.0'
 
   gem.add_development_dependency 'appraisal', '~> 2.0.1'
   gem.add_development_dependency 'bundler'

--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -79,7 +79,7 @@ class Chef
         @event.emit_to_datadog dog
         @tags.send_update_to_datadog dog
       rescue => e
-        Chef::Log.error("Could not send/emit to Datadog:\n" + e)
+        Chef::Log.error("Could not send/emit to Datadog:\n" + e.to_s)
         Chef::Log.error('Event data to be submitted was:')
         Chef::Log.error(@event.event_title)
         Chef::Log.error(@event.event_body)


### PR DESCRIPTION
Fi the unit tests for the time being, but we should upgrade chef-handler-datadog to support latest version. Also fixes some error output.