### PR TITLE
Bump dogapi to 1.42.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   Exclude:
     - 'spec/*.rb'
     - '*/vendor/**/*'
+  TargetRubyVersion: 2.3
 
 # 80 characters is a nice goal, but not worth currently changing in existing
 # code for the sake of changing it to conform to a length set in 1928 (IBM).

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,11 @@ AllCops:
   Exclude:
     - 'spec/*.rb'
     - '*/vendor/**/*'
-  TargetRubyVersion: 2.3
+
+# Remove RequiredRubyVersion check, it necessarily fails in CI as we test
+# with different ruby versions.
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 # 80 characters is a nice goal, but not worth currently changing in existing
 # code for the sake of changing it to conform to a length set in 1928 (IBM).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    chef-handler-datadog (0.12.3)
-      dogapi (~> 1.38.0)
+    chef-handler-datadog (0.13.0)
+      dogapi (~> 1.42.0)
 
 GEM
   remote: http://rubygems.org/
@@ -67,7 +67,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    dogapi (1.38.0)
+    dogapi (1.42.0)
       multi_json
     dotenv (2.7.5)
     ed25519 (1.2.4)

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -2,14 +2,13 @@
 
 require File.expand_path('lib/chef_handler_datadog', __dir__)
 
+# rubocop:disable Gemspec/RequiredRubyVersion
 Gem::Specification.new do |gem|
   gem.name                  = 'chef-handler-datadog'
   gem.summary               = 'Chef Handler reports events and metrics to Datadog'
   gem.description           = 'This Handler will report the events and metrics for a chef-client run to Datadog.'
   gem.license               = 'BSD'
   gem.version               = ChefHandlerDatadog::VERSION
-
-  gem.required_ruby_version = '>= 2.3.0'
 
   gem.files                 = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
   gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -2,7 +2,6 @@
 
 require File.expand_path('lib/chef_handler_datadog', __dir__)
 
-# rubocop:disable Gemspec/RequiredRubyVersion
 Gem::Specification.new do |gem|
   gem.name                  = 'chef-handler-datadog'
   gem.summary               = 'Chef Handler reports events and metrics to Datadog'
@@ -10,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.license               = 'BSD'
   gem.version               = ChefHandlerDatadog::VERSION
 
+  gem.required_ruby_version = '>= 2.3.0'
   gem.files                 = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
   gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'BSD'
   gem.version       = ChefHandlerDatadog::VERSION
 
-  gem.files         = `git ls-files`.split($\) # rubocop:disable SpecialGlobalVars
+  gem.files         = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
   gem.executables   = gem.files.grep(%r{^bin\/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)\/})
   gem.require_paths = ['lib']

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -3,18 +3,17 @@
 require File.expand_path('lib/chef_handler_datadog', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.name                  = 'chef-handler-datadog'
-  gem.summary               = 'Chef Handler reports events and metrics to Datadog'
-  gem.description           = 'This Handler will report the events and metrics for a chef-client run to Datadog.'
-  gem.license               = 'BSD'
-  gem.version               = ChefHandlerDatadog::VERSION
+  gem.name             = 'chef-handler-datadog'
+  gem.summary          = 'Chef Handler reports events and metrics to Datadog'
+  gem.description      = 'This Handler will report the events and metrics for a chef-client run to Datadog.'
+  gem.license          = 'BSD'
+  gem.version          = ChefHandlerDatadog::VERSION
 
-  gem.required_ruby_version = '>= 2.3.0'
-  gem.files                 = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
-  gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths         = ['lib']
-  gem.extra_rdoc_files      = ['README.md', 'LICENSE.txt']
+  gem.files            = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
+  gem.executables      = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.test_files       = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths    = ['lib']
+  gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
   gem.add_dependency 'dogapi', '~> 1.42.0'
 

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
-  gem.add_dependency 'dogapi', '~> 1.38.0'
+  gem.add_dependency 'dogapi', '~> 1.42.0'
 
   gem.add_development_dependency 'appraisal', '~> 2.0.1'
   gem.add_development_dependency 'bundler'

--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -3,17 +3,19 @@
 require File.expand_path('lib/chef_handler_datadog', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.name          = 'chef-handler-datadog'
-  gem.summary       = 'Chef Handler reports events and metrics to Datadog'
-  gem.description   = 'This Handler will report the events and metrics for a chef-client run to Datadog.'
-  gem.license       = 'BSD'
-  gem.version       = ChefHandlerDatadog::VERSION
+  gem.name                  = 'chef-handler-datadog'
+  gem.summary               = 'Chef Handler reports events and metrics to Datadog'
+  gem.description           = 'This Handler will report the events and metrics for a chef-client run to Datadog.'
+  gem.license               = 'BSD'
+  gem.version               = ChefHandlerDatadog::VERSION
 
-  gem.files         = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
-  gem.executables   = gem.files.grep(%r{^bin\/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)\/})
-  gem.require_paths = ['lib']
-  gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
+  gem.required_ruby_version = '>= 2.3.0'
+
+  gem.files                 = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
+  gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths         = ['lib']
+  gem.extra_rdoc_files      = ['README.md', 'LICENSE.txt']
 
   gem.add_dependency 'dogapi', '~> 1.42.0'
 


### PR DESCRIPTION
### What does this PR do?

Updates the dogapi gem dependency to its latest version, in particular to get https://github.com/DataDog/dogapi-rb/pull/219.

### Motivation

When instantiating a client on Windows, dogapi tries to do `hostname -f`, which fails on Windows Server 2012 and newer with:

```
sethostname: Use the Network Control Panel Applet to set hostname.
hostname -s is not supported.
```

Before 1.39.0, this error was not properly rescued, resulting in warnings appearing in chef logs.