### PR TITLE
Allow skipping SSL verification

### DIFF
--- a/chef-handler-datadog.gemspec
+++ b/chef-handler-datadog.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths    = ['lib']
   gem.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
-  gem.add_dependency 'dogapi', '~> 1.43.0'
+  gem.add_dependency 'dogapi', '~> 1.44.0'
 
   gem.add_development_dependency 'appraisal', '~> 2.0.1'
   gem.add_development_dependency 'bundler'

--- a/lib/chef/handler/datadog.rb
+++ b/lib/chef/handler/datadog.rb
@@ -137,7 +137,8 @@ class Chef
                         nil,   # device
                         false, # silent
                         nil,   # timeout
-                        url
+                        url,
+                        config[:skip_ssl_validation]
             ))
           rescue => e
             Chef::Log.error("Could not create API Client '#{url}'\n #{e.to_s}")


### PR DESCRIPTION
Allows setting `:skip_ssl_validation` in the config to skip SSL verification.

Fixes: #127