### PR TITLE
Use https instead of http to download dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chef-handler-datadog.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       dogapi (~> 1.44.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)


### PR DESCRIPTION
https://github.com/DataDog/chef-handler-datadog/security/code-scanning/1