### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   ### Chef 12.0
   specs-ruby23-chef-120: &specs
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       API_KEY: somefakeapikey
       APPLICATION_KEY: somefakeapplicationkey
@@ -117,7 +118,8 @@ jobs:
       RUBY_VERSION: '2.5.1'
 
   verify-gemfile.lock-dependencies:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       API_KEY: somefakeapikey
       APPLICATION_KEY: somefakeapplicationkey

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 version: 2
 jobs:
   ### Chef 12.0
-  specs-ruby23-chef-120: &specs
+  specs-ruby24-chef-120: &specs
     machine:
       image: ubuntu-2004:202201-02
     environment:
       API_KEY: somefakeapikey
       APPLICATION_KEY: somefakeapplicationkey
       CHEF_VERSION: '12.0'
-      RUBY_VERSION: '2.3.8'
+      RUBY_VERSION: '2.4.9'
     steps:
       - checkout
       - run:
@@ -24,14 +24,6 @@ jobs:
           name: Run tests
           command: rvm $RUBY_VERSION --verbose do bundle exec rake
 
-  specs-ruby24-chef-120:
-    <<: *specs
-    environment:
-      API_KEY: somefakeapikey
-      APPLICATION_KEY: somefakeapplicationkey
-      CHEF_VERSION: '12.0'
-      RUBY_VERSION: '2.4.9'
-
   specs-ruby25-chef-120:
     <<: *specs
     environment:
@@ -41,14 +33,6 @@ jobs:
       RUBY_VERSION: '2.5.1'
 
   ### Chef 12.7
-  specs-ruby23-chef-127:
-    <<: *specs
-    environment:
-      API_KEY: somefakeapikey
-      APPLICATION_KEY: somefakeapplicationkey
-      CHEF_VERSION: '12.7.0'
-      RUBY_VERSION: '2.3.8'
-
   specs-ruby24-chef-127:
     <<: *specs
     environment:
@@ -66,14 +50,6 @@ jobs:
       RUBY_VERSION: '2.5.1'
 
   ### Chef 13
-  specs-ruby23-chef-130:
-    <<: *specs
-    environment:
-      API_KEY: somefakeapikey
-      APPLICATION_KEY: somefakeapplicationkey
-      CHEF_VERSION: '13.0'
-      RUBY_VERSION: '2.3.8'
-
   specs-ruby24-chef-130:
     <<: *specs
     environment:
@@ -143,15 +119,12 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - specs-ruby23-chef-120
       - specs-ruby24-chef-120
       - specs-ruby25-chef-120
 
-      - specs-ruby23-chef-127
       - specs-ruby24-chef-127
       - specs-ruby25-chef-127
 
-      - specs-ruby23-chef-130
       - specs-ruby24-chef-130
       - specs-ruby25-chef-130
 


### PR DESCRIPTION
The CI was consistently failing for some time (between August 16th and the last PR in February)

This PR updates the image we use for those jobs, so that we use the same as the `chef-datadog` repo
It also removes the ruby 2.3 jobs, since this version has reached EOL for about 4 years now, and was already dropped from the chef-datadog repo.