### PR TITLE
chore(github): reduce workflow token permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,8 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Github token permissions should follow the least privilege principle

Reset workflow permissions to validate we can enable read-only default permissions at repository level to provide a strong baseline protection measure